### PR TITLE
[layout] Add flag for disabling X86 heuristic for frame object ordering.

### DIFF
--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -84,6 +84,11 @@ public:
   /// on top of callsite padding, which ruins the callsite alignment.
   bool DisableBlockAlign;
 
+  /// X86 uses a heuristic to order the symbols in the local stack.
+  /// AArch64 does not follow a similar strategy, so disable this ordering
+  /// to keep the same stack layout.
+  bool DisableX86FrameObjOrder;
+
   /// Additional paths to search for `.include` directives when using the
   /// integrated assembler.
   std::vector<std::string> IASSearchPaths;

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -3082,7 +3082,7 @@ void X86FrameLowering::orderFrameObjects(
   const MachineFrameInfo &MFI = MF.getFrameInfo();
 
   // Don't waste time if there's nothing to do.
-  if (ObjectsToAllocate.empty())
+  if (ObjectsToAllocate.empty() || MF.getTarget().Options.MCOptions.DisableX86FrameObjOrder)
     return;
 
   // Create an array of all MFI objects. We won't need all of these

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -74,6 +74,11 @@ static cl::opt<bool> DisableBlockAlign("disable-block-align",
                                 cl::desc("Disable alignment at the beginning of basic blocks."),
                                 cl::init(false));
 
+static cl::opt<bool>
+    DisableX86FrameObjOrder("disable-x86-frame-obj-order",
+                            cl::desc("Disable heuristic for frame object ordering in X86 frame lowering."),
+                            cl::init(false));
+
 static cl::opt<std::string>
     SplitDwarfOutputFile("split-dwarf-output",
                          cl::desc(".dwo output filename"),
@@ -463,6 +468,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
   Options.MCOptions.SplitDwarfFile = SplitDwarfFile;
   Options.MCOptions.CallsitePaddingFilename = CallsitePaddingFilename;
   Options.MCOptions.DisableBlockAlign = DisableBlockAlign;
+  Options.MCOptions.DisableX86FrameObjOrder = DisableX86FrameObjOrder;
 
   std::unique_ptr<TargetMachine> Target(TheTarget->createTargetMachine(
       TheTriple.getTriple(), CPUStr, FeaturesStr, Options, getRelocModel(),


### PR DESCRIPTION
X86 uses a heuristic to order frame objects in `X86FrameLowering::orderFrameObjects`, but AArch64 does not have such implementation.

For now, we add a flag to optionally deactivate this (based on Marcus' suggestion). In the future, we might want to consider implementing a similar approach for AArch64, which shouldn't be that hard.