### PR TITLE
Add parameter flag for setting the single CSR alignment in AArch64.

### DIFF
--- a/llvm/include/llvm/MC/MCTargetOptions.h
+++ b/llvm/include/llvm/MC/MCTargetOptions.h
@@ -89,6 +89,11 @@ public:
   /// to keep the same stack layout.
   bool DisableX86FrameObjOrder;
 
+  /// AArch64 will align single callee-saved registers to 16 bytes.
+  /// We add this parameter to experiment with 8 bytes also,
+  /// for keeping the same stack layout with X86.
+  int AArch64CSRAlignment;
+
   /// Additional paths to search for `.include` directives when using the
   /// integrated assembler.
   std::vector<std::string> IASSearchPaths;

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -1808,7 +1808,8 @@ static void computeCalleeSaveRegisterPairs(
       Offset -= 8;
       assert(Offset % 16 == 0);
       assert(MFI.getObjectAlignment(RPI.FrameIdx) <= 16);
-      MFI.setObjectAlignment(RPI.FrameIdx, 16);
+      assert(MF.getTarget().Options.MCOptions.AArch64CSRAlignment <= 16);
+      MFI.setObjectAlignment(RPI.FrameIdx, MF.getTarget().Options.MCOptions.AArch64CSRAlignment);
     }
 
     assert(Offset % Scale == 0);
@@ -2173,7 +2174,7 @@ void AArch64FrameLowering::determineCalleeSaves(MachineFunction &MF,
 
   // Adding the size of additional 64bit GPR saves.
   CSStackSize += 8 * (SavedRegs.count() - NumSavedRegs);
-  unsigned AlignedCSStackSize = alignTo(CSStackSize, 16);
+  unsigned AlignedCSStackSize = alignTo(CSStackSize, MF.getTarget().Options.MCOptions.AArch64CSRAlignment);
   LLVM_DEBUG(dbgs() << "Estimated stack frame size: "
                << EstimatedStackSize + AlignedCSStackSize
                << " bytes.\n");

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -79,6 +79,11 @@ static cl::opt<bool>
                             cl::desc("Disable heuristic for frame object ordering in X86 frame lowering."),
                             cl::init(false));
 
+static cl::opt<int>
+    AArch64CSRAlignment("aarch64-csr-alignment",
+                            cl::desc("Set the alignment of single callee-saved registers for AArch64 (defaults to 16)."),
+                            cl::init(16));
+
 static cl::opt<std::string>
     SplitDwarfOutputFile("split-dwarf-output",
                          cl::desc(".dwo output filename"),
@@ -469,6 +474,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
   Options.MCOptions.CallsitePaddingFilename = CallsitePaddingFilename;
   Options.MCOptions.DisableBlockAlign = DisableBlockAlign;
   Options.MCOptions.DisableX86FrameObjOrder = DisableX86FrameObjOrder;
+  Options.MCOptions.AArch64CSRAlignment = AArch64CSRAlignment;
 
   std::unique_ptr<TargetMachine> Target(TheTarget->createTargetMachine(
       TheTriple.getTriple(), CPUStr, FeaturesStr, Options, getRelocModel(),


### PR DESCRIPTION
We would like to be able to experiment with the CSR alignment in AArch64, which by default is 16. It seems that 8 is useful for getting the same layout with X86.