### PR TITLE
[layout] Convert MOVSS/MOVSD X86 instructions to not rematerializable.

### DIFF
--- a/llvm/lib/Target/X86/X86InstrSSE.td
+++ b/llvm/lib/Target/X86/X86InstrSSE.td
@@ -255,7 +255,7 @@ defm MOVSS : sse12_move<FR32, X86Movss, v4f32, f32mem, "movss",
 defm MOVSD : sse12_move<FR64, X86Movsd, v2f64, f64mem, "movsd",
                         SSEPackedDouble, "MOVSD", UseSSE2>, XD;
 
-let canFoldAsLoad = 1, isReMaterializable = 1 in {
+let canFoldAsLoad = 1, isReMaterializable = 0 in {
   defm MOVSS : sse12_move_rm<FR32, v4f32, f32mem, loadf32, X86vzload32, "movss",
                              SSEPackedSingle>, XS;
   defm MOVSD : sse12_move_rm<FR64, v2f64, f64mem, loadf64, X86vzload64, "movsd",


### PR DESCRIPTION
In X86 MOVSDrm_alt is rematerializable, which means that it doesn't have to be spilled in memory.
Essentially, X86 uses rip-relative addressing to get the constant values of the global variables,
directly from the stack, whereas AArch64 loads the constant to a GPR, and then copies the GPR to the FPR.
So, we always treat MOVSS/MOVSD as not rematerializable, so X86 will be forced to also spill in the stack.

Fixes: 
https://github.com/systems-nuts/UnASL/issues/26
https://github.com/systems-nuts/UnASL/issues/34

See the last issue for more info.