### PR TITLE
[layout] Treat LEA64 x86 instructions as cheap as a move.

### DIFF
--- a/llvm/lib/Target/X86/X86InstrArithmetic.td
+++ b/llvm/lib/Target/X86/X86InstrArithmetic.td
@@ -31,7 +31,7 @@ def LEA64_32r : I<0x8D, MRMSrcMem,
                   [(set GR32:$dst, lea64_32addr:$src)]>,
                   OpSize32, Requires<[In64BitMode]>;
 
-let isReMaterializable = 1 in
+let isReMaterializable = 1, isAsCheapAsAMove = 1 in
 def LEA64r   : RI<0x8D, MRMSrcMem, (outs GR64:$dst), (ins lea64mem:$src),
                   "lea{q}\t{$src|$dst}, {$dst|$src}",
                   [(set GR64:$dst, lea64addr:$src)]>;


### PR DESCRIPTION
When we are accessing references inside a loop, X86 will usually use LEA
instructions that are hoisted outside of the loop. This causes greater
register pressure. The main problem, however, is that AArch64 will use
simple arithmetic instructions, which are usually rematerialized instead
of hoisted. To fix that difference, we set the `isAsCheapAsAMove` flag
for LEA64r, so that `simple-register-coalescing` will also rematerialize LEAs.
Moreover, this makes the flag `sink-insts-to-avoid-spills` unnecessary.

Closes:
https://github.com/systems-nuts/UnASL/issues/31

Also fixes in (probably) a better way:
https://github.com/systems-nuts/UnASL/issues/30