### PR TITLE
[layout] Immediates in instructions have the same size as in AArch64.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -345,6 +345,9 @@ def FeatureRandGen : SubtargetFeature<"rand", "HasRandGen",
 def FeatureMTE : SubtargetFeature<"mte", "HasMTE",
     "true", "Enable Memory Tagging Extension" >;
 
+def FeatureDisableHoistInLowering : SubtargetFeature<"disable-hoist-in-lowering", "DisableHoistInLowering",
+    "true", "Disable hoisting of instructions while lowering the IR.">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8209,6 +8209,10 @@ bool AArch64TargetLowering::isTruncateFree(EVT VT1, EVT VT2) const {
 /// Not profitable if I and it's user can form a FMA instruction
 /// because we prefer FMSUB/FMADD.
 bool AArch64TargetLowering::isProfitableToHoist(Instruction *I) const {
+
+  if (Subtarget->disableHoistInLowering())
+    return false;
+
   if (I->getOpcode() != Instruction::FMul)
     return true;
 

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -135,6 +135,7 @@ protected:
   bool HasBTI = false;
   bool HasRandGen = false;
   bool HasMTE = false;
+  bool DisableHoistInLowering = false;
 
   // Arm SVE2 extensions
   bool HasSVE2AES = false;
@@ -385,6 +386,7 @@ public:
   bool hasBTI() const { return HasBTI; }
   bool hasRandGen() const { return HasRandGen; }
   bool hasMTE() const { return HasMTE; }
+  bool disableHoistInLowering() const { return DisableHoistInLowering; }
   // Arm SVE2 extensions
   bool hasSVE2AES() const { return HasSVE2AES; }
   bool hasSVE2SM4() const { return HasSVE2SM4; }

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -450,6 +450,14 @@ def FeatureMergeToThreeWayBranch : SubtargetFeature<"merge-to-threeway-branch",
                                         "Merge branches to a three-way "
                                         "conditional branch">;
 
+// Immediates in instructions have the same size as in AArch64.
+// Otherwise, a register is used to hold the larger immediates.
+// Currently supported only for instructions that are using constant values.
+def FeatureAArch64SizedImmediates : SubtargetFeature<"aarch64-sized-imm",
+                                        "AArch64SizedImm", "true",
+                                        "Can encode only the immediates supported "
+                                        " in AArch64 (12-bit with optional 12 shift)">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -443,6 +443,9 @@ protected:
   /// Threeway branch is profitable in this subtarget.
   bool ThreewayBranchProfitable = false;
 
+  /// AArch64 sized immediates in this subtarget.
+  bool AArch64SizedImm = false;
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -698,6 +701,7 @@ public:
   bool hasPCONFIG() const { return HasPCONFIG; }
   bool hasSGX() const { return HasSGX; }
   bool threewayBranchProfitable() const { return ThreewayBranchProfitable; }
+  bool aarch64SizedImm() const { return AArch64SizedImm; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }
   bool useRetpolineIndirectCalls() const { return UseRetpolineIndirectCalls; }


### PR DESCRIPTION
We encode in instructions only immediates that can be represented
using 12 bits, with an optional bit to declare that the immediate
is a value shifted by 12. Otherwise, a register is used to hold larger
immediates. This is how AArch64 represents immediates.
We support this currently for instructions that are using constant
values in the DAG.

Fixes `create_seq` problem in https://github.com/systems-nuts/UnASL/issues/62.