### PR TITLE
[layout] Do not hoist ADRP instruction out of loops.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -147,7 +147,6 @@ def AArch64LocalRecover : SDNode<"ISD::LOCAL_RECOVER",
                                   SDTypeProfile<1, 1, [SDTCisSameAs<0, 1>,
                                                        SDTCisInt<1>]>>;
 
-
 //===----------------------------------------------------------------------===//
 // AArch64-specific DAG Nodes.
 //
@@ -453,7 +452,7 @@ def ADJCALLSTACKUP : Pseudo<(outs), (ins i32imm:$amt1, i32imm:$amt2),
                             Sched<[]>;
 } // Defs = [SP], Uses = [SP], hasSideEffects = 1, isCodeGenOnly = 1
 
-let isReMaterializable = 1, isCodeGenOnly = 1 in {
+let isReMaterializable = 1, isCodeGenOnly = 1, isAsCheapAsAMove = 1 in {
 // FIXME: The following pseudo instructions are only needed because remat
 // cannot handle multiple instructions.  When that changes, they can be
 // removed, along with the AArch64Wrapper node.
@@ -505,7 +504,7 @@ def ADDlowTLS
                                             tglobaltlsaddr:$low))]>,
       Sched<[WriteAdr]>;
 
-} // isReMaterializable, isCodeGenOnly
+} // isReMaterializable, isCodeGenOnly, isAsCheapAsAMove
 
 def : Pat<(AArch64LOADgot tglobaltlsaddr:$addr),
           (LOADgot tglobaltlsaddr:$addr)>;


### PR DESCRIPTION
Hoisting ADRP creates an arch-specific value in the case of AArch64,
whereas LEA instructions are not hoisted because of:
https://github.com/blackgeorge-boom/llvm-project/pull/13
In order to make the coalescer to bring ADRP back in the loop,
after licm, we need to do a similar change.

Addresses: https://github.com/systems-nuts/UnASL/issues/74

Eventually, we want to add this option with a TableGen flag, but I've not found a good way to give this through the command line in `isAsCheapAsAMove`.