### PR TITLE
[layout] Use MOV32mr instead of MOV32ri with store and CopyToReg as users

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -364,6 +364,15 @@ namespace {
             return true;
           }
           else {
+            // We want to count stores of immediates as real uses.
+            if (User->getOpcode() == ISD::STORE &&
+                User->getOperand(1).getNode() == N) {
+              UseCount++;
+            }
+            else if (User->getOpcode() == ISD::CopyToReg &&
+                User->getOperand(2).getNode() == N) {
+              UseCount++;
+            }
             continue;
           }
         }


### PR DESCRIPTION
When the same SD constant is used in X86 by a store and a CopyToReg
as users, we want to reuse the same virtual register for this,
since this is what AArch64 does. Therefore, we try to match with
MOV32mr, so that the constant should come from a register.

Addresses: https://github.com/systems-nuts/UnASL/issues/76

Similar to: https://github.com/blackgeorge-boom/llvm-project/pull/14