### PR TITLE
[layout] Do not Use MOV32mr instead of MOV32ri, for the zero constant with store and CopyToReg as users.

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -318,6 +318,16 @@ namespace {
         Segment = CurDAG->getRegister(0, MVT::i16);
     }
 
+    bool shouldAvoidImmediateInstFormsForSizeExceptZero(SDNode *N) const {
+      if (auto *ConstantNode = dyn_cast<ConstantSDNode>(N)) {
+        auto ConstantNodeValue = ConstantNode->getSExtValue();
+        if (ConstantNodeValue == 0)
+          return false;
+        return shouldAvoidImmediateInstFormsForSize(N);
+      }
+      return false;
+    }
+
     // Utility function to determine whether we should avoid selecting
     // immediate forms of instructions for better code size or not.
     // At a high level, we'd like to avoid such instructions when

--- a/llvm/lib/Target/X86/X86InstrInfo.td
+++ b/llvm/lib/Target/X86/X86InstrInfo.td
@@ -1055,7 +1055,7 @@ def relocImm16_su : PatLeaf<(i16 relocImm), [{
     return !shouldAvoidImmediateInstFormsForSize(N);
 }]>;
 def relocImm32_su : PatLeaf<(i32 relocImm), [{
-    return !shouldAvoidImmediateInstFormsForSize(N);
+    return !shouldAvoidImmediateInstFormsForSizeExceptZero(N);
 }]>;
 
 def i16immSExt8_su : PatLeaf<(i16immSExt8), [{


### PR DESCRIPTION
Addresses: https://github.com/systems-nuts/UnASL/issues/78