### PR TITLE
[layout] Add flag for disabling materializing of fp immediates in AArch64

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -348,6 +348,9 @@ def FeatureMTE : SubtargetFeature<"mte", "HasMTE",
 def FeatureDisableHoistInLowering : SubtargetFeature<"disable-hoist-in-lowering", "DisableHoistInLowering",
     "true", "Disable hoisting of instructions while lowering the IR.">;
 
+def FeatureDisableFPImmMaterialize : SubtargetFeature<"disable-fp-imm-materialize", "DisableFPImmMaterialize",
+    "true", "Disable materialization of non-zero floating-point immediates.">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -5497,6 +5497,9 @@ bool AArch64TargetLowering::isFPImmLegal(const APFloat &Imm, EVT VT,
   // TODO: fmov h0, w0 is also legal, however on't have an isel pattern to
   //       generate that fmov.
 
+  if (Subtarget->disableFPImmMaterialize() && ImmInt != 0)
+    return false;
+
   // If we can not materialize in immediate field for fmov, check if the
   // value can be encoded as the immediate operand of a logical instruction.
   // The immediate value will be created with either MOVZ, MOVN, or ORR.

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -136,6 +136,7 @@ protected:
   bool HasRandGen = false;
   bool HasMTE = false;
   bool DisableHoistInLowering = false;
+  bool DisableFPImmMaterialize = false;
 
   // Arm SVE2 extensions
   bool HasSVE2AES = false;
@@ -387,6 +388,7 @@ public:
   bool hasRandGen() const { return HasRandGen; }
   bool hasMTE() const { return HasMTE; }
   bool disableHoistInLowering() const { return DisableHoistInLowering; }
+  bool disableFPImmMaterialize() const { return DisableFPImmMaterialize; }
   // Arm SVE2 extensions
   bool hasSVE2AES() const { return HasSVE2AES; }
   bool hasSVE2SM4() const { return HasSVE2SM4; }


### PR DESCRIPTION
Only zero fp-immediates are materialized using `FMOVDi`-like
instructions, as in the case of X86.

Addresses: https://github.com/systems-nuts/UnASL/issues/81