### PR TITLE
[layout] Align one-byte sized stack objects to four bytes.

### DIFF
--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -614,7 +614,7 @@ public:
     resetDataLayout(IsX32
                         ? "e-m:e-p:32:32-i64:64-f80:128-n8:16:32:64-S128"
                         : IsWinCOFF ? "e-m:w-i64:64-f80:128-n8:16:32:64-S128"
-                                    : "e-m:e-i64:64-f80:128-n8:16:32:64-S128");
+                                    : "e-m:e-i8:8:32-i64:64-f80:128-n8:16:32:64-S128");
 
     // Use fpret only for long double.
     RealTypeUsesObjCFPRet = (1 << TargetInfo::LongDouble);

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -60,6 +60,11 @@ static cl::opt<bool> EnableCondBrFoldingPass("x86-condbr-folding",
                                         "folding pass"),
                                cl::init(false), cl::Hidden);
 
+static cl::opt<bool> AlignBytesToFour("align-bytes-to-four",
+                                cl::desc("Sets the preferred alignment of"
+                                         "bytes to four bytes."),
+                                cl::init(false), cl::Hidden);
+
 extern "C" void LLVMInitializeX86Target() {
   // Register the target.
   RegisterTargetMachine<X86TargetMachine> X(getTheX86_32Target());
@@ -117,8 +122,11 @@ static std::string computeDataLayout(const Triple &TT) {
     Ret += "-p:32:32";
 
   // Some ABIs align 64 bit integers and doubles to 64 bits, others to 32.
-  if (TT.isArch64Bit() || TT.isOSWindows() || TT.isOSNaCl())
+  if (TT.isArch64Bit() || TT.isOSWindows() || TT.isOSNaCl()) {
+    if (AlignBytesToFour)
+      Ret += "-i8:8:32";
     Ret += "-i64:64";
+  }
   else if (TT.isOSIAMCU())
     Ret += "-i64:32-f64:32";
   else


### PR DESCRIPTION
Addresses: https://github.com/systems-nuts/UnASL/issues/71