### PR TITLE
[layout] Handle MOV32ri64 instructions with immediates in stacktransformmetadata pass.

### DIFF
--- a/llvm/lib/Target/X86/X86Values.cpp
+++ b/llvm/lib/Target/X86/X86Values.cpp
@@ -171,6 +171,8 @@ MachineLiveValPtr X86Values::getMachineValue(const MachineInstr *MI) const {
   case X86::MOV32ri64:
     // TODO the upper 32 bits of this reference are supposed to be masked
     MO = &MI->getOperand(1);
+    if (MO->isImm())
+      Val = new MachineImmediate(8, MO->getImm(), MI, false);
     if(TargetValues::isSymbolValue(MO))
       Val = new MachineSymbolRef(*MO, false, MI);
     break;


### PR DESCRIPTION
So far, the code was not handling the case where the operand
was an immediate.

Addresses: https://github.com/systems-nuts/UnASL/issues/84