### PR TITLE
[layout] Do not encode immediates in multiplications for X86.

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -458,6 +458,12 @@ def FeatureAArch64SizedImmediates : SubtargetFeature<"aarch64-sized-imm",
                                         "Can encode only the immediates supported "
                                         " in AArch64 (12-bit with optional 12 shift)">;
 
+// Instructions with multiplication between register and immediate are supported.
+// AArch64 does not support this.
+def FeatureMultiplyWithImm : SubtargetFeature<"multiply-with-imm",
+                                        "MultiplyWithImm", "true",
+                                        "Multiplication of registers and immediates is supported">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86InstrArithmetic.td
+++ b/llvm/lib/Target/X86/X86InstrArithmetic.td
@@ -198,6 +198,7 @@ let Defs = [EFLAGS] in {
 // first so that they are slightly preferred to the ri forms.
 
 // Register-Integer Signed Integer Multiply
+let Predicates = [MultiplyWithImm] in {
 def IMUL16rri8 : Ii8<0x6B, MRMSrcReg,                       // GR16 = GR16*I8
                      (outs GR16:$dst), (ins GR16:$src1, i16i8imm:$src2),
                      "imul{w}\t{$src2, $src1, $dst|$dst, $src1, $src2}",
@@ -234,6 +235,7 @@ def IMUL64rri32 : RIi32S<0x69, MRMSrcReg,                    // GR64 = GR64*I32
                          [(set GR64:$dst, EFLAGS,
                              (X86smul_flag GR64:$src1, i64immSExt32:$src2))]>,
                          Sched<[WriteIMul64Imm]>;
+} // Predicates
 
 // Memory-Integer Signed Integer Multiply
 def IMUL16rmi8 : Ii8<0x6B, MRMSrcMem,                       // GR16 = [mem16]*I8

--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -2037,6 +2037,7 @@ def : Pat<(mul GR64:$src1, (loadi64 addr:$src2)),
           (IMUL64rm GR64:$src1, addr:$src2)>;
 
 // mul reg, imm
+let Predicates = [MultiplyWithImm] in {
 def : Pat<(mul GR16:$src1, imm:$src2),
           (IMUL16rri GR16:$src1, imm:$src2)>;
 def : Pat<(mul GR32:$src1, imm:$src2),
@@ -2049,6 +2050,7 @@ def : Pat<(mul GR64:$src1, i64immSExt8:$src2),
           (IMUL64rri8 GR64:$src1, i64immSExt8:$src2)>;
 def : Pat<(mul GR64:$src1, i64immSExt32:$src2),
           (IMUL64rri32 GR64:$src1, i64immSExt32:$src2)>;
+} // Predicates
 
 // reg = mul mem, imm
 def : Pat<(mul (loadi16 addr:$src1), imm:$src2),

--- a/llvm/lib/Target/X86/X86InstrInfo.td
+++ b/llvm/lib/Target/X86/X86InstrInfo.td
@@ -988,6 +988,8 @@ def HasMFence    : Predicate<"Subtarget->hasMFence()">;
 def UseRetpolineIndirectCalls : Predicate<"Subtarget->useRetpolineIndirectCalls()">;
 def NotUseRetpolineIndirectCalls : Predicate<"!Subtarget->useRetpolineIndirectCalls()">;
 
+def MultiplyWithImm : Predicate<"Subtarget->hasMultiplyWithImm()">;
+
 //===----------------------------------------------------------------------===//
 // X86 Instruction Format Definitions.
 //

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -446,6 +446,9 @@ protected:
   /// AArch64 sized immediates in this subtarget.
   bool AArch64SizedImm = false;
 
+  /// Multiplication of registers and immediates in this subtarget.
+  bool MultiplyWithImm = false;
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -702,6 +705,7 @@ public:
   bool hasSGX() const { return HasSGX; }
   bool threewayBranchProfitable() const { return ThreewayBranchProfitable; }
   bool aarch64SizedImm() const { return AArch64SizedImm; }
+  bool hasMultiplyWithImm() const { return MultiplyWithImm; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }
   bool useRetpolineIndirectCalls() const { return UseRetpolineIndirectCalls; }


### PR DESCRIPTION
In the case of AArch64, there are no intsructions for multiplying
a register with immediate, thus an extra register is used to hold
the immediate. We emulate the same behavior for X86 by not generating
these kinds of instructions.

Use with `mattr=-multiply-with-imm`

Addresses: https://github.com/systems-nuts/UnASL/issues/86