### PR TITLE
[layout] Add required ELF flags when printing human-readable assembly

### DIFF
--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -476,11 +476,11 @@ void MCObjectFileInfo::initELFMCObjectFileInfo(const Triple &T, bool Large) {
 
   UnwindAddrRangeSection =
       Ctx->getELFSection(".stack_transform.unwind_arange", ELF::SHT_PROGBITS,
-                         0, sizeof(uint64_t) + sizeof(uint64_t),
+                         ELF::SHF_MERGE, sizeof(uint64_t) + sizeof(uint64_t),
 			 "");
   UnwindInfoSection =
       Ctx->getELFSection(".stack_transform.unwind", ELF::SHT_PROGBITS,
-			 0, sizeof(uint16_t) + sizeof(int16_t), "");
+			 ELF::SHF_MERGE, sizeof(uint16_t) + sizeof(int16_t), "");
   UnwindAddrRangeSection->setAlignment(sizeof(uint64_t));
   UnwindInfoSection->setAlignment(sizeof(uint16_t) + sizeof(int16_t));
 


### PR DESCRIPTION
The ELF sections added by the Popcorn compiler modifications trigger an assertion due to a missing ELF flag in the emitted section when producing human-readable assembly.
The affected ELF sections are:

- `.stack_transform.unwind`
- `.stack_transform.unwind_arange`

This patch:

- Adds the required `SHF_MERGE` flag in the aforementioned emitted ELF sections.
- Adds debug printing for this issue to increase visibility for potential future uses.


Addresses: https://github.com/systems-nuts/UnASL/issues/91