### PR TITLE
[layout] Do not hoist the ADRP instruction.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -1647,7 +1647,7 @@ def : InstAlias<"cneg $dst, $src, $cc",
 //===----------------------------------------------------------------------===//
 // PC-relative instructions.
 //===----------------------------------------------------------------------===//
-let isReMaterializable = 1 in {
+let isReMaterializable = 0, isAsCheapAsAMove = 1 in {
 let hasSideEffects = 0, mayStore = 0, mayLoad = 0 in {
 def ADR  : ADRI<0, "adr", adrlabel,
                 [(set GPR64:$Xd, (AArch64adr tglobaladdr:$label))]>;
@@ -1655,7 +1655,7 @@ def ADR  : ADRI<0, "adr", adrlabel,
 
 def ADRP : ADRI<1, "adrp", adrplabel,
                 [(set GPR64:$Xd, (AArch64adrp tglobaladdr:$label))]>;
-} // isReMaterializable = 1
+} // isReMaterializable = 0, isAsCheapAsAMove = 1
 
 // page address of a constant pool entry, block address
 def : Pat<(AArch64adr tconstpool:$cp), (ADR tconstpool:$cp)>;


### PR DESCRIPTION
This is different from 5b0b02933263da7d319079c3ba307aed758f26b1 .
The problem now is with passing globals by value, because AArch64
needs two instructions (`adrp`+`ldr`), and when `adrp` is hoisted
the coalescer cannot bring it back. So, now, we don't hoist
`adrp` at all.

In the other case, we had to sink back `MOVaddr`, which later
expands into `adrp`+`add`.

Addresses: https://github.com/systems-nuts/UnASL/issues/93