### PR TITLE
[layout] Use only temporary registers for ADRP instructions (not coming from MOVaddr)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -351,6 +351,10 @@ def FeatureDisableHoistInLowering : SubtargetFeature<"disable-hoist-in-lowering"
 def FeatureDisableFPImmMaterialize : SubtargetFeature<"disable-fp-imm-materialize", "DisableFPImmMaterialize",
     "true", "Disable materialization of non-zero floating-point immediates.">;
 
+// TODO: Not used currently, but maybe we'll find a way to choose the register class of the instruction based on this.
+def FeatureTempRegsADRP : SubtargetFeature<"temp-regs-adrp", "TempRegsADRP",
+    "true", "Use only temporary registers for ADR/ADRP (not MOVaddr) and treat those as cheap as a move.">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1932,7 +1932,7 @@ class BaseCRC32<bit sf, bits<2> sz, bit C, RegisterClass StreamReg,
 //---
 
 class ADRI<bit page, string asm, Operand adr, list<dag> pattern>
-    : I<(outs GPR64:$Xd), (ins adr:$label), asm, "\t$Xd, $label", "",
+    : I<(outs GPR64temp:$Xd), (ins adr:$label), asm, "\t$Xd, $label", "",
         pattern>,
       Sched<[WriteI]> {
   bits<5>  Xd;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -147,6 +147,9 @@ def AArch64LocalRecover : SDNode<"ISD::LOCAL_RECOVER",
                                   SDTypeProfile<1, 1, [SDTCisSameAs<0, 1>,
                                                        SDTCisInt<1>]>>;
 
+def TempRegsADRP        : Predicate<"Subtarget->hasTempRegsADRP()">;
+def NotTempRegsADRP     : Predicate<"!Subtarget->hasTempRegsADRP()">;
+
 //===----------------------------------------------------------------------===//
 // AArch64-specific DAG Nodes.
 //
@@ -1647,14 +1650,15 @@ def : InstAlias<"cneg $dst, $src, $cc",
 //===----------------------------------------------------------------------===//
 // PC-relative instructions.
 //===----------------------------------------------------------------------===//
-let isReMaterializable = 0, isAsCheapAsAMove = 1 in {
+
+let isReMaterializable = 1, isAsCheapAsAMove = 1 in {
 let hasSideEffects = 0, mayStore = 0, mayLoad = 0 in {
 def ADR  : ADRI<0, "adr", adrlabel,
-                [(set GPR64:$Xd, (AArch64adr tglobaladdr:$label))]>;
+                [(set GPR64temp:$Xd, (AArch64adr tglobaladdr:$label))]>;
 } // hasSideEffects = 0
 
 def ADRP : ADRI<1, "adrp", adrplabel,
-                [(set GPR64:$Xd, (AArch64adrp tglobaladdr:$label))]>;
+                [(set GPR64temp:$Xd, (AArch64adrp tglobaladdr:$label))]>;
 } // isReMaterializable = 0, isAsCheapAsAMove = 1
 
 // page address of a constant pool entry, block address

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -165,6 +165,12 @@ def GPR64sp : RegisterClass<"AArch64", [i64], 64, (add GPR64common, SP)> {
   let AltOrderSelect = [{ return 1; }];
 }
 
+def GPR64temp : RegisterClass<"AArch64", [i64], 64,
+                                (add (sequence "X%u", 6, 8), (sequence "X%u", 16, 18))> {
+  let AltOrders = [(rotl GPR64temp, 8)];
+  let AltOrderSelect = [{ return 1; }];
+}
+
 def GPR32sponly : RegisterClass<"AArch64", [i32], 32, (add WSP)>;
 def GPR64sponly : RegisterClass<"AArch64", [i64], 64, (add SP)>;
 

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -137,6 +137,7 @@ protected:
   bool HasMTE = false;
   bool DisableHoistInLowering = false;
   bool DisableFPImmMaterialize = false;
+  bool TempRegsADRP = false;
 
   // Arm SVE2 extensions
   bool HasSVE2AES = false;
@@ -389,6 +390,7 @@ public:
   bool hasMTE() const { return HasMTE; }
   bool disableHoistInLowering() const { return DisableHoistInLowering; }
   bool disableFPImmMaterialize() const { return DisableFPImmMaterialize; }
+  bool hasTempRegsADRP() const { return TempRegsADRP; }
   // Arm SVE2 extensions
   bool hasSVE2AES() const { return HasSVE2AES; }
   bool hasSVE2SM4() const { return HasSVE2SM4; }


### PR DESCRIPTION
With consecutive calls of the same global argument (by value),
the compiler will use a CSR as the destination of the ADRP.
This register needs to be pushed, but X86 has rip-relative
mem-to-reg moves, which avoid this issue. So, we need to use
temporary registers in the case of AArch64.

@compor I didn't find a good way to add this change as a flag, so it's hardcoded for now, as the other older changes regarding the register classes modifications.

Addresses: https://github.com/systems-nuts/UnASL/issues/102