### PR TITLE
[layout] Do not move directly 32-bit immediates to memory in X86.

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -464,6 +464,12 @@ def FeatureMultiplyWithImm : SubtargetFeature<"multiply-with-imm",
                                         "MultiplyWithImm", "true",
                                         "Multiplication of registers and immediates is supported">;
 
+// Moving non-zero immediates directly to memory is supported.
+// AArch64 does not support this.
+def FeatureMoveNonZeroImmToMem: SubtargetFeature<"non-zero-imm-to-mem",
+                                        "MoveNonZeroImmToMem", "true",
+                                        "Moving non-zero immediates to memory is supported">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -318,6 +318,16 @@ namespace {
         Segment = CurDAG->getRegister(0, MVT::i16);
     }
 
+    bool useImmediateInstForms(SDNode *N) const {
+      if (Subtarget->hasMoveNonZeroImmToMem())
+        return !shouldAvoidImmediateInstFormsForSizeExceptZero(N);
+      if (auto *ConstantNode = dyn_cast<ConstantSDNode>(N)) {
+        auto ConstantNodeValue = ConstantNode->getSExtValue();
+        return ConstantNodeValue == 0;
+      }
+      return true;
+    }
+
     bool shouldAvoidImmediateInstFormsForSizeExceptZero(SDNode *N) const {
       if (auto *ConstantNode = dyn_cast<ConstantSDNode>(N)) {
         auto ConstantNodeValue = ConstantNode->getSExtValue();

--- a/llvm/lib/Target/X86/X86InstrInfo.td
+++ b/llvm/lib/Target/X86/X86InstrInfo.td
@@ -1060,6 +1060,10 @@ def relocImm32_su : PatLeaf<(i32 relocImm), [{
     return !shouldAvoidImmediateInstFormsForSizeExceptZero(N);
 }]>;
 
+def relocImm32_su_for_mov : PatLeaf<(i32 relocImm), [{
+    return useImmediateInstForms(N);
+}]>;
+
 def i16immSExt8_su : PatLeaf<(i16immSExt8), [{
     return !shouldAvoidImmediateInstFormsForSize(N);
 }]>;
@@ -1575,7 +1579,7 @@ def MOV16mi : Ii16<0xC7, MRM0m, (outs), (ins i16mem:$dst, i16imm:$src),
                    [(store (i16 relocImm16_su:$src), addr:$dst)]>, OpSize16;
 def MOV32mi : Ii32<0xC7, MRM0m, (outs), (ins i32mem:$dst, i32imm:$src),
                    "mov{l}\t{$src, $dst|$dst, $src}",
-                   [(store (i32 relocImm32_su:$src), addr:$dst)]>, OpSize32;
+                   [(store (i32 relocImm32_su_for_mov:$src), addr:$dst)]>, OpSize32;
 def MOV64mi32 : RIi32S<0xC7, MRM0m, (outs), (ins i64mem:$dst, i64i32imm:$src),
                        "mov{q}\t{$src, $dst|$dst, $src}",
                        [(store i64relocImmSExt32_su:$src, addr:$dst)]>,

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -449,6 +449,9 @@ protected:
   /// Multiplication of registers and immediates in this subtarget.
   bool MultiplyWithImm = false;
 
+  /// Move directly non-zero immediates to memory in this subtarget.
+  bool MoveNonZeroImmToMem = false;
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -706,6 +709,7 @@ public:
   bool threewayBranchProfitable() const { return ThreewayBranchProfitable; }
   bool aarch64SizedImm() const { return AArch64SizedImm; }
   bool hasMultiplyWithImm() const { return MultiplyWithImm; }
+  bool hasMoveNonZeroImmToMem() const { return MoveNonZeroImmToMem; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }
   bool useRetpolineIndirectCalls() const { return UseRetpolineIndirectCalls; }


### PR DESCRIPTION
In the case of AArch64, these immediates need to be loaded into a
register first. Sometimes, a CSR will be used, which breaks the
unified address space with X86, which can move directly immediates
to memory. Add a flag to deactivate this X86 capability.

We may need to do the same for other immediate sizes.

Addresses: https://github.com/systems-nuts/UnASL/issues/104