### PR TITLE
[layout] Add flag for reserving a register scavenging spill slot.

### DIFF
--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -72,6 +72,11 @@ X86RegisterInfo::X86RegisterInfo(const Triple &TT)
   }
 }
 
+bool X86RegisterInfo::requiresRegisterScavenging(
+    const MachineFunction &MF) const {
+  return true;
+}
+
 bool
 X86RegisterInfo::trackLivenessAfterRegAlloc(const MachineFunction &MF) const {
   // ExecutionDomainFix, BreakFalseDeps and PostRAScheduler require liveness.

--- a/llvm/lib/Target/X86/X86RegisterInfo.h
+++ b/llvm/lib/Target/X86/X86RegisterInfo.h
@@ -54,6 +54,8 @@ public:
   // FIXME: This should be tablegen'd like getDwarfRegNum is
   int getSEHRegNum(unsigned i) const;
 
+  bool requiresRegisterScavenging(const MachineFunction &MF) const override;
+
   /// Code Generation virtual methods...
   ///
   bool trackLivenessAfterRegAlloc(const MachineFunction &MF) const override;


### PR DESCRIPTION
AArch64 tries to reserve an extra CSR during register scavenging,
in order to use it to access stack offsets larger than 255,
which cannot be encoded directly to instructions as an offset.
If the stack size is larger than 255, but AArch64 cannot find a CSR,
it will reserve a special spill slot for that purpose.
To align that behaviour with X86, we add a flag to always (conservatively)
assign this spill slot for both architectures.

Addresses: https://github.com/systems-nuts/UnASL/issues/110