### PR TITLE
[layout] Add X86 flag for following AArch64 constant cost model.

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -470,6 +470,11 @@ def FeatureMoveNonZeroImmToMem: SubtargetFeature<"non-zero-imm-to-mem",
                                         "MoveNonZeroImmToMem", "true",
                                         "Moving non-zero immediates to memory is supported">;
 
+// Use the constant cost model employed by AArch64.
+def FeatureAArch64ConstantCostModel: SubtargetFeature<"aarch64-constant-cost-model",
+                                        "AArch64ConstantCostModel", "true",
+                                        "The constant cost model of AArch64 is supported">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -28710,6 +28710,19 @@ bool X86TargetLowering::isLegalICmpImmediate(int64_t Imm) const {
 }
 
 bool X86TargetLowering::isLegalAddImmediate(int64_t Imm) const {
+
+  // When hoisting constants in `ConstantHoist`, we need to have aligned
+  // behavior between X86 and AArch64 on this function.
+  if (Subtarget.hasAArch64ConstantCostModel()) {
+    // Same encoding for add/sub, just flip the sign.
+    Imm = std::abs(Imm);
+    bool IsLegal =
+        ((Imm >> 12) == 0 || ((Imm & 0xfff) == 0 && Imm >> 24 == 0));
+    LLVM_DEBUG(dbgs() << "Is " << Imm << " legal add imm: "
+                      << (IsLegal ? "yes" : "no") << "\n");
+    return IsLegal;
+  }
+
   // Can also use sub to handle negated immediates.
   return isInt<32>(Imm);
 }

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -452,6 +452,10 @@ protected:
   /// Move directly non-zero immediates to memory in this subtarget.
   bool MoveNonZeroImmToMem = false;
 
+  /// Follow AArch64 cost model for constants in this subtarget.
+  bool AArch64ConstantCostModel = false;
+
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -710,6 +714,7 @@ public:
   bool aarch64SizedImm() const { return AArch64SizedImm; }
   bool hasMultiplyWithImm() const { return MultiplyWithImm; }
   bool hasMoveNonZeroImmToMem() const { return MoveNonZeroImmToMem; }
+  bool hasAArch64ConstantCostModel() const { return AArch64ConstantCostModel; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }
   bool useRetpolineIndirectCalls() const { return UseRetpolineIndirectCalls; }


### PR DESCRIPTION
AArch64 and X86 follow a different strategy for materializing constants,
e.g., whether to encode the full constant, or encode a smaller one and
add the rest of the value as a separate instruction.
We want to align both architectures in this respect.

Addresses: https://github.com/systems-nuts/UnASL/issues/115