### PR TITLE
[layout] Add flag for simplified addressing in the case of register offset in X86.

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -475,6 +475,20 @@ def FeatureAArch64ConstantCostModel: SubtargetFeature<"aarch64-constant-cost-mod
                                         "AArch64ConstantCostModel", "true",
                                         "The constant cost model of AArch64 is supported">;
 
+// Simplify addressing of instructions in the case of register offset for X86.
+// E.g., do not encode things like:
+//
+// mov    ebx,DWORD PTR [rbp+rax*4-0x30]
+//
+// but prefer something like:
+//
+// lea    r15,[rbp-0x30]
+// mov    ebx,DWORD PTR [r15+rax*4]
+//
+def FeatureSimpleRegOffsetAddr: SubtargetFeature<"simple-reg-offset-addr",
+                                        "SimpleRegOffsetAddr", "true",
+                                        "A simplified register offset addressing is supported">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -455,6 +455,8 @@ protected:
   /// Follow AArch64 cost model for constants in this subtarget.
   bool AArch64ConstantCostModel = false;
 
+  /// Simple register offset addressing in this subtarget.
+  bool SimpleRegOffsetAddr = false;
 
   /// What processor and OS we're targeting.
   Triple TargetTriple;
@@ -715,6 +717,7 @@ public:
   bool hasMultiplyWithImm() const { return MultiplyWithImm; }
   bool hasMoveNonZeroImmToMem() const { return MoveNonZeroImmToMem; }
   bool hasAArch64ConstantCostModel() const { return AArch64ConstantCostModel; }
+  bool hasSimpleRegOffsetAddr() const { return SimpleRegOffsetAddr; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }
   bool useRetpolineIndirectCalls() const { return UseRetpolineIndirectCalls; }


### PR DESCRIPTION
We introduce an extra LEA instruction for computing the address,
instead of encoding things like [base + scaled register + offset] in
one command, to follow what AArch64 is doing in register offset addressing.

Addresses: https://github.com/systems-nuts/UnASL/issues/117