### PR TITLE
[layout] Make check for simplified addressing with register offset SHL-specific

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -2350,6 +2350,9 @@ bool X86DAGToDAGISel::selectAddr(SDNode *Parent, SDValue N, SDValue &Base,
   // for a similar address space layout.
   if (N.getOpcode() == ISD::ADD && Subtarget->hasSimpleRegOffsetAddr()) {
     SDValue LHS = N.getOperand(0);
+    SDValue RHS = N.getOperand(1);
+    if (LHS.getOpcode() != ISD::SHL && RHS.getOpcode() != ISD::SHL)
+      return true;
     Base = LHS;
   }
 


### PR DESCRIPTION
We add a more specific check for the case that solves:
042f2f81e548e07c2bf4199c61117d6dfcd5cfcd
From now on, we will check if at least one of the operands of the add
node in the DAG are of SHL type, which probably means that we are
in the case of addressing with scaled-register offset.
Otherwise, the previous solution was introducing assymetries for
other addressing mode cases.

Addresses: https://github.com/systems-nuts/UnASL/issues/129