### PR TITLE
[layout] Use only temp registers for X86::MOV32r0.

### DIFF
--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -265,8 +265,8 @@ def MORESTACK_RET_RESTORE_R10 : I<0, Pseudo, (outs), (ins), "", []>;
 // FIXME: remove when we can teach regalloc that xor reg, reg is ok.
 let Defs = [EFLAGS], isReMaterializable = 1, isAsCheapAsAMove = 1,
     isPseudo = 1, isMoveImm = 1, AddedComplexity = 10 in
-def MOV32r0  : I<0, Pseudo, (outs GR32:$dst), (ins), "",
-                 [(set GR32:$dst, 0)]>, Sched<[WriteZero]>;
+def MOV32r0  : I<0, Pseudo, (outs GR32temp:$dst), (ins), "",
+                 [(set GR32temp:$dst, 0)]>, Sched<[WriteZero]>;
 
 // Other widths can also make use of the 32-bit xor, which may have a smaller
 // encoding and avoid partial register updates.

--- a/llvm/lib/Target/X86/X86RegisterInfo.td
+++ b/llvm/lib/Target/X86/X86RegisterInfo.td
@@ -409,6 +409,10 @@ def GR32 : RegisterClass<"X86", [i32], 32,
                          (add EAX, ECX, EDX, ESI, EDI, EBX, EBP, ESP,
                               R8D, R9D, R10D, R11D, R14D, R15D, R12D, R13D)>;
 
+def GR32temp : RegisterClass<"X86", [i32], 32,
+                         (add EAX, ECX, EDX, ESI, EDI,
+                              R8D, R9D, R10D, R11D, R14D, R12D, R13D)>;
+
 // GR64 - 64-bit GPRs. This oddly includes RIP, which isn't accurate, since
 // RIP isn't really a register and it can't be used anywhere except in an
 // address, but it doesn't cause trouble.


### PR DESCRIPTION
There are cases where X86 reuses the zero constant, consuming
callee-saved registers. But, AArch64 has a dedicated wzr register,
so it doesn't need to do the same. We remove CSR registers from the
pool of MOV32r0 to solve this issue. In the future, we would like
to add this option as a flag.

Addresses: https://github.com/systems-nuts/UnASL/issues/134