### PR TITLE
[layout] Treat structs of doubles the same way in both architectures.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -355,6 +355,18 @@ def FeatureDisableFPImmMaterialize : SubtargetFeature<"disable-fp-imm-materializ
 def FeatureTempRegsADRP : SubtargetFeature<"temp-regs-adrp", "TempRegsADRP",
     "true", "Use only temporary registers for ADR/ADRP (not MOVaddr) and treat those as cheap as a move.">;
 
+// This favors code like:
+//   ldrsw	x16, [sp, #0x20]
+//   ldr	x19, [sp, #0x48]
+//   add	x8, x8, x16, lsl #4
+//   ldp	x8, x16, [x8]
+//   stp	x8, x16, [sp, #0x8]  ; 2*i64
+// over:
+//   ldr	q0, [x8, x16, lsl #4]
+//   str	q0, [sp]
+def FeatureAvoidF128 : SubtargetFeature<"avoid-f128", "AvoidF128",
+    "true", "Avoid the use of f128 memory operand types.">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8738,6 +8738,7 @@ EVT AArch64TargetLowering::getOptimalMemOpType(
       !FuncAttributes.hasFnAttribute(Attribute::NoImplicitFloat);
   bool CanUseNEON = Subtarget->hasNEON() && CanImplicitFloat;
   bool CanUseFP = Subtarget->hasFPARMv8() && CanImplicitFloat;
+  bool AvoidF128 = Subtarget->avoidF128();
   // Only use AdvSIMD to implement memset of 32-byte and above. It would have
   // taken one instruction to materialize the v2i64 zero and one store (with
   // restrictive addressing mode). Just do i64 stores.
@@ -8754,7 +8755,7 @@ EVT AArch64TargetLowering::getOptimalMemOpType(
   if (CanUseNEON && IsMemset && !IsSmallMemset &&
       AlignmentIsAcceptable(MVT::v2i64, 16))
     return MVT::v2i64;
-  if (CanUseFP && !IsSmallMemset && AlignmentIsAcceptable(MVT::f128, 16))
+  if (CanUseFP && !IsSmallMemset && AlignmentIsAcceptable(MVT::f128, 16) && !AvoidF128)
     return MVT::f128;
   if (Size >= 8 && AlignmentIsAcceptable(MVT::i64, 8))
     return MVT::i64;

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -138,6 +138,7 @@ protected:
   bool DisableHoistInLowering = false;
   bool DisableFPImmMaterialize = false;
   bool TempRegsADRP = false;
+  bool AvoidF128 = false;
 
   // Arm SVE2 extensions
   bool HasSVE2AES = false;
@@ -391,6 +392,7 @@ public:
   bool disableHoistInLowering() const { return DisableHoistInLowering; }
   bool disableFPImmMaterialize() const { return DisableFPImmMaterialize; }
   bool hasTempRegsADRP() const { return TempRegsADRP; }
+  bool avoidF128() const { return AvoidF128; }
   // Arm SVE2 extensions
   bool hasSVE2AES() const { return HasSVE2AES; }
   bool hasSVE2SM4() const { return HasSVE2SM4; }

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -489,6 +489,19 @@ def FeatureSimpleRegOffsetAddr: SubtargetFeature<"simple-reg-offset-addr",
                                         "SimpleRegOffsetAddr", "true",
                                         "A simplified register offset addressing is supported">;
 
+// Force the use of vector types.
+// E.g., this favors the generation of code like:
+//   movups xmm0,XMMWORD PTR [rax+rax*1]
+//   movaps XMMWORD PTR [rbp-0x50],xmm0
+// instead of:
+//   mov    rdx,QWORD PTR [rax+rax*1]
+//   mov    QWORD PTR [rbp-0x48],rdx ; i64
+//   mov    rax,QWORD PTR [rcx+rax*1+0x8]
+//   mov    QWORD PTR [rbp-0x40],rax ; i64
+def FeatureForceVectorMemOp: SubtargetFeature<"force-vector-mem-op",
+                                        "ForceVectorMemOp", "true",
+                                        "Favors the use of vector memory operand types.">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -2057,7 +2057,7 @@ EVT X86TargetLowering::getOptimalMemOpType(
     bool ZeroMemset, bool MemcpyStrSrc,
     const AttributeList &FuncAttributes) const {
   if (!FuncAttributes.hasFnAttribute(Attribute::NoImplicitFloat)) {
-    if (Size >= 16 && (!Subtarget.isUnalignedMem16Slow() ||
+    if (Size >= 16 && (!Subtarget.isUnalignedMem16Slow() || Subtarget.forceVectorMemOp() ||
                        ((DstAlign == 0 || DstAlign >= 16) &&
                         (SrcAlign == 0 || SrcAlign >= 16)))) {
       // FIXME: Check if unaligned 32-byte accesses are slow.

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -458,6 +458,9 @@ protected:
   /// Simple register offset addressing in this subtarget.
   bool SimpleRegOffsetAddr = false;
 
+  /// Favors using vector memory operand types.
+  bool ForceVectorMemOp = false;
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -718,6 +721,7 @@ public:
   bool hasMoveNonZeroImmToMem() const { return MoveNonZeroImmToMem; }
   bool hasAArch64ConstantCostModel() const { return AArch64ConstantCostModel; }
   bool hasSimpleRegOffsetAddr() const { return SimpleRegOffsetAddr; }
+  bool forceVectorMemOp() const { return ForceVectorMemOp; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }
   bool useRetpolineIndirectCalls() const { return UseRetpolineIndirectCalls; }


### PR DESCRIPTION
AArch64 uses the f128 memory operand type, whereas X86 uses two
i64 types. We add a flag to the AArch64 architecture to avoid the
use of f128. We also add a flag to the X86 architecture to use
vector mem ops instead. The first flag seems to solve more problems
in the case of ft. But, we add both to also examine performance
tradeoffs.

Addresses: https://github.com/systems-nuts/UnASL/issues/141