### PR TITLE
[layout] Make checking for simplified register addressing mode more robust

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -2353,7 +2353,9 @@ bool X86DAGToDAGISel::selectAddr(SDNode *Parent, SDValue N, SDValue &Base,
     SDValue RHS = N.getOperand(1);
     if (LHS.getOpcode() != ISD::SHL && RHS.getOpcode() != ISD::SHL)
       return true;
-    Base = LHS;
+    if (LHS.getOpcode() == X86ISD::WrapperRIP || RHS.getOpcode() == X86ISD::WrapperRIP)
+      return true;
+    Base = (LHS.getOpcode() == ISD::SHL)? RHS : LHS;
   }
 
   return true;


### PR DESCRIPTION
Take into account that the add operator in the DAG is commutative.
Also, exclude from the addressing mode simplification the case where
the array is global, since AArch64/X86 behave similarly in that case.

Addresses: https://github.com/systems-nuts/UnASL/issues/143
Addresses: https://github.com/systems-nuts/UnASL/issues/144