### PR TITLE
[layout] Avoid optimizing multiplication with specific constants in X86.

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -502,6 +502,11 @@ def FeatureForceVectorMemOp: SubtargetFeature<"force-vector-mem-op",
                                         "ForceVectorMemOp", "true",
                                         "Favors the use of vector memory operand types.">;
 
+// Avoid optimizing multiplication with constants like (2^n + 2/4/6).
+def FeatureAvoidOptimizingMulCase1: SubtargetFeature<"avoid-opt-mul-1",
+                                        "AvoidOptimizingMulCase1", "true",
+                                        "Avoid optimizing multiplication with (2^n + 2/4/6).">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -461,6 +461,9 @@ protected:
   /// Favors using vector memory operand types.
   bool ForceVectorMemOp = false;
 
+  /// Avoid optimizing mul with (2^n + 2/4/6)
+  bool AvoidOptimizingMulCase1 = false;
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -722,6 +725,7 @@ public:
   bool hasAArch64ConstantCostModel() const { return AArch64ConstantCostModel; }
   bool hasSimpleRegOffsetAddr() const { return SimpleRegOffsetAddr; }
   bool forceVectorMemOp() const { return ForceVectorMemOp; }
+  bool avoidOptimizingMulCase1() const { return AvoidOptimizingMulCase1; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }
   bool useRetpolineIndirectCalls() const { return UseRetpolineIndirectCalls; }


### PR DESCRIPTION
The constants are of the form 2^N+2/4/8.

Addresses: https://github.com/systems-nuts/UnASL/issues/151