### PR TITLE
[layout] Handle architecture-specific stack slots in stackmaps.

### DIFF
--- a/llvm/lib/Target/X86/X86Values.h
+++ b/llvm/lib/Target/X86/X86Values.h
@@ -1,3 +1,6 @@
+#ifndef LLVM_LIB_TARGET_X86_X86VALUES_H
+#define LLVM_LIB_TARGET_X86_X86VALUES_H
+
 //===--------- X86TargetValues.cpp - X86 specific value generator ---------===//
 //
 //                     The LLVM Compiler Infrastructure
@@ -22,4 +25,6 @@ private:
   MachineLiveVal *genLEAInstructions(const MachineInstr *LEA) const;
 };
 
-}
+} // namespace llvm
+
+#endif


### PR DESCRIPTION
So far, architecture-specific values that are stored in the stack
were not included in the stackmap section of the ELF binary.
For example, when the value of a global constant was spilled,
we weren't including this liveness information in the stackmaps.
Thus, our tools could not detect whether this live value would end
up in the same stack location.

This patch introduces support for these stack slots and also handles
X86 values generated by rip-relative memory-to-register operations,
with `MOVSDrm_alt`.

Addresses: https://github.com/systems-nuts/UnASL/issues/87
Addresses: https://github.com/systems-nuts/UnASL/issues/88