### PR TITLE
[layout] Avoid wide multiplication-addition instructions in AArch64.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -367,6 +367,14 @@ def FeatureTempRegsADRP : SubtargetFeature<"temp-regs-adrp", "TempRegsADRP",
 def FeatureAvoidF128 : SubtargetFeature<"avoid-f128", "AvoidF128",
     "true", "Avoid the use of f128 memory operand types.">;
 
+// Avoid instructions like:
+//      umull	x17, w17, w20
+// where the source operands are 32-bit and the destination is 64-bit.
+// X86 does not support this, using only 64-bit operands for a 64-bit destination.
+// This leads to differences in register allocation.
+def FeatureAvoidUMADDL : SubtargetFeature<"avoid-wide-mul-add", "AvoidUMADDL",
+    "true", "Disable the use of wide multiplication-addition of 32-bit to 64-bit.">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -150,6 +150,8 @@ def AArch64LocalRecover : SDNode<"ISD::LOCAL_RECOVER",
 def TempRegsADRP        : Predicate<"Subtarget->hasTempRegsADRP()">;
 def NotTempRegsADRP     : Predicate<"!Subtarget->hasTempRegsADRP()">;
 
+def hasUMADDL           : Predicate<"!Subtarget->avoidUMADDL()">;
+
 //===----------------------------------------------------------------------===//
 // AArch64-specific DAG Nodes.
 //
@@ -1115,8 +1117,11 @@ def UMSUBLrrr : WideMulAccum<1, 0b101, "umsubl", sub, zext>;
 
 def : Pat<(i64 (mul (sext GPR32:$Rn), (sext GPR32:$Rm))),
           (SMADDLrrr GPR32:$Rn, GPR32:$Rm, XZR)>;
+
+let Predicates = [hasUMADDL] in {
 def : Pat<(i64 (mul (zext GPR32:$Rn), (zext GPR32:$Rm))),
           (UMADDLrrr GPR32:$Rn, GPR32:$Rm, XZR)>;
+} // Predicates = [hasUMADDL]
 
 def : Pat<(i64 (ineg (mul (sext GPR32:$Rn), (sext GPR32:$Rm)))),
           (SMSUBLrrr GPR32:$Rn, GPR32:$Rm, XZR)>;

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -139,6 +139,7 @@ protected:
   bool DisableFPImmMaterialize = false;
   bool TempRegsADRP = false;
   bool AvoidF128 = false;
+  bool AvoidUMADDL = false;
 
   // Arm SVE2 extensions
   bool HasSVE2AES = false;
@@ -393,6 +394,7 @@ public:
   bool disableFPImmMaterialize() const { return DisableFPImmMaterialize; }
   bool hasTempRegsADRP() const { return TempRegsADRP; }
   bool avoidF128() const { return AvoidF128; }
+  bool avoidUMADDL() const { return AvoidUMADDL; }
   // Arm SVE2 extensions
   bool hasSVE2AES() const { return HasSVE2AES; }
   bool hasSVE2SM4() const { return HasSVE2SM4; }


### PR DESCRIPTION
AArch64 supports instructions where the source operands are 32-bit,
whereas the destination is 64-bit. In X86, all operands will be 64-bit,
for a 64-bit destination, which leads to differences in register allocation,
in case there is a register used both as 32-bit and as 64-bit:
In X86 only one register will be used for that,
whereas AArch64 will employ one 32-bit and one 64-bit register.

Addresses: https://github.com/systems-nuts/UnASL/issues/179