### PR TITLE
Add flags for tablegen changes

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -302,6 +302,9 @@ set(LLVM_TARGETS_TO_BUILD "all"
 set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD ""
   CACHE STRING "Semicolon-separated list of experimental targets to build.")
 
+set(LLVM_UNIFICO_TABLEGEN_FEATURES ""
+  CACHE STRING "Semicolon-separated list of Unifico TableGen features to build.")
+
 option(BUILD_SHARED_LIBS
   "Build all libraries as shared libraries instead of static" OFF)
 

--- a/llvm/cmake/modules/TableGen.cmake
+++ b/llvm/cmake/modules/TableGen.cmake
@@ -58,6 +58,11 @@ function(tablegen project ofn)
     endif()
   endif()
 
+
+  if (LLVM_UNIFICO_TABLEGEN_FEATURES)
+    list(APPEND ARGN ${LLVM_UNIFICO_TABLEGEN_FEATURES})
+  endif()
+
   # We need both _TABLEGEN_TARGET and _TABLEGEN_EXE in the  DEPENDS list
   # (both the target and the file) to have .inc files rebuilt on
   # a tablegen change, as cmake does not propagate file-level dependencies

--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -351,10 +351,6 @@ def FeatureDisableHoistInLowering : SubtargetFeature<"disable-hoist-in-lowering"
 def FeatureDisableFPImmMaterialize : SubtargetFeature<"disable-fp-imm-materialize", "DisableFPImmMaterialize",
     "true", "Disable materialization of non-zero floating-point immediates.">;
 
-// TODO: Not used currently, but maybe we'll find a way to choose the register class of the instruction based on this.
-def FeatureTempRegsADRP : SubtargetFeature<"temp-regs-adrp", "TempRegsADRP",
-    "true", "Use only temporary registers for ADR/ADRP (not MOVaddr) and treat those as cheap as a move.">;
-
 // This favors code like:
 //   ldrsw	x16, [sp, #0x20]
 //   ldr	x19, [sp, #0x48]

--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -73,8 +73,15 @@ def CC_AArch64_AAPCS : CallingConv<[
   // Handle i1, i8, i16, i32, i64, f32, f64 and v2f64 by passing in registers,
   // up to eight each of GPR and FPR.
   CCIfType<[i1, i8, i16], CCPromoteToType<i32>>,
+
+#ifndef UNIFICO_GPR_CALLING_CONV
+  CCIfType<[i32], CCAssignToRegWithShadow<[W0, W1, W2, W3, W4, W5, W6, W7],
+                                          [X0, X1, X2, X3, X4, X5, X6, X7]>>,
+#else
   CCIfType<[i32], CCAssignToRegWithShadow<[W0, W1, W2, W3, W4, W5],
                                           [X0, X1, X2, X3, X4, X5]>>,
+#endif
+
   // i128 is split to two i64s, we can't fit half to register X7.
   CCIfType<[i64], CCIfSplit<CCAssignToRegWithShadow<[X0, X2, X4, X6],
                                                     [X0, X1, X3, X5]>>>,
@@ -82,8 +89,14 @@ def CC_AArch64_AAPCS : CallingConv<[
   // i128 is split to two i64s, and its stack alignment is 16 bytes.
   CCIfType<[i64], CCIfSplit<CCAssignToStackWithShadow<8, 16, [X7]>>>,
 
+#ifndef UNIFICO_GPR_CALLING_CONV
+  CCIfType<[i64], CCAssignToRegWithShadow<[X0, X1, X2, X3, X4, X5, X6, X7],
+                                          [W0, W1, W2, W3, W4, W5, W6, W7]>>,
+#else
   CCIfType<[i64], CCAssignToRegWithShadow<[X0, X1, X2, X3, X4, X5],
                                           [W0, W1, W2, W3, W4, W5]>>,
+#endif
+
   CCIfType<[f16], CCAssignToRegWithShadow<[H0, H1, H2, H3, H4, H5, H6, H7],
                                           [Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7]>>,
   CCIfType<[f32], CCAssignToRegWithShadow<[S0, S1, S2, S3, S4, S5, S6, S7],
@@ -121,10 +134,19 @@ def RetCC_AArch64_AAPCS : CallingConv<[
                          CCBitConvertToType<f128>>>,
 
   CCIfType<[i1, i8, i16], CCPromoteToType<i32>>,
+
+#ifndef UNIFICO_GPR_CALLING_CONV
+  CCIfType<[i32], CCAssignToRegWithShadow<[W0, W1, W2, W3, W4, W5, W6, W7],
+                                          [X0, X1, X2, X3, X4, X5, X6, X7]>>,
+  CCIfType<[i64], CCAssignToRegWithShadow<[X0, X1, X2, X3, X4, X5, X6, X7],
+                                          [W0, W1, W2, W3, W4, W5, W6, W7]>>,
+#else
   CCIfType<[i32], CCAssignToRegWithShadow<[W8, W2],
                                           [X8, X2]>>,
   CCIfType<[i64], CCAssignToRegWithShadow<[X8, X2],
                                           [W8, W2]>>,
+#endif
+
   CCIfType<[f16], CCAssignToRegWithShadow<[H0, H1],
                                           [Q0, Q1]>>,
   CCIfType<[f32], CCAssignToRegWithShadow<[S0, S1],
@@ -306,7 +328,11 @@ def CC_AArch64_GHC : CallingConv<[
 // It would be better to model its preservation semantics properly (create a
 // vreg on entry, use it in RET & tail call generation; make that vreg def if we
 // end up saving LR as part of a call frame). Watch this space...
-def CSR_AArch64_AAPCS : CalleeSavedRegs<(add LR, FP, X19, X20)>;
+def CSR_AArch64_AAPCS : CalleeSavedRegs<(add LR, FP, X19, X20
+#ifndef UNIFICO_GPR_CALLING_CONV
+                                         , X21, X22, X23, X24, X25, X26, X27, X28
+#endif
+                                         )>;
 
 // Win64 has unwinding codes for an (FP,LR) pair, save_fplr and save_fplr_x.
 // We put FP before LR, so that frame lowering logic generates (FP,LR) pairs,

--- a/llvm/lib/Target/AArch64/AArch64CallingConvention.td
+++ b/llvm/lib/Target/AArch64/AArch64CallingConvention.td
@@ -147,6 +147,19 @@ def RetCC_AArch64_AAPCS : CallingConv<[
                                           [W8, W2]>>,
 #endif
 
+#ifndef UNIFICO_FPR_CALLING_CONV
+  CCIfType<[f16], CCAssignToRegWithShadow<[H0, H1, H2, H3, H4, H5, H6, H7],
+                                          [Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7]>>,
+  CCIfType<[f32], CCAssignToRegWithShadow<[S0, S1, S2, S3, S4, S5, S6, S7],
+                                          [Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7]>>,
+  CCIfType<[f64], CCAssignToRegWithShadow<[D0, D1, D2, D3, D4, D5, D6, D7],
+                                          [Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7]>>,
+  CCIfType<[v1i64, v2i32, v4i16, v8i8, v1f64, v2f32, v4f16],
+      CCAssignToRegWithShadow<[D0, D1, D2, D3, D4, D5, D6, D7],
+                              [Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7]>>,
+  CCIfType<[f128, v2i64, v4i32, v8i16, v16i8, v4f32, v2f64, v8f16],
+      CCAssignToReg<[Q0, Q1, Q2, Q3, Q4, Q5, Q6, Q7]>>
+#else
   CCIfType<[f16], CCAssignToRegWithShadow<[H0, H1],
                                           [Q0, Q1]>>,
   CCIfType<[f32], CCAssignToRegWithShadow<[S0, S1],
@@ -158,6 +171,7 @@ def RetCC_AArch64_AAPCS : CallingConv<[
                               [Q0, Q1]>>,
   CCIfType<[f128, v2i64, v4i32, v8i16, v16i8, v4f32, v2f64, v8f16],
       CCAssignToReg<[Q0, Q1]>>
+#endif
 ]>;
 
 // Vararg functions on windows pass floats in integer registers
@@ -331,6 +345,9 @@ def CC_AArch64_GHC : CallingConv<[
 def CSR_AArch64_AAPCS : CalleeSavedRegs<(add LR, FP, X19, X20
 #ifndef UNIFICO_GPR_CALLING_CONV
                                          , X21, X22, X23, X24, X25, X26, X27, X28
+#endif
+#ifndef UNIFICO_FPR_CALLING_CONV
+                                         , D8, D9, D10, D11, D12, D13, D14, D15
 #endif
                                          )>;
 

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1932,7 +1932,11 @@ class BaseCRC32<bit sf, bits<2> sz, bit C, RegisterClass StreamReg,
 //---
 
 class ADRI<bit page, string asm, Operand adr, list<dag> pattern>
+#ifndef UNIFICO_REMAT_RULES
+    : I<(outs GPR64:$Xd), (ins adr:$label), asm, "\t$Xd, $label", "",
+#else
     : I<(outs GPR64temp:$Xd), (ins adr:$label), asm, "\t$Xd, $label", "",
+#endif
         pattern>,
       Sched<[WriteI]> {
   bits<5>  Xd;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -147,9 +147,6 @@ def AArch64LocalRecover : SDNode<"ISD::LOCAL_RECOVER",
                                   SDTypeProfile<1, 1, [SDTCisSameAs<0, 1>,
                                                        SDTCisInt<1>]>>;
 
-def TempRegsADRP        : Predicate<"Subtarget->hasTempRegsADRP()">;
-def NotTempRegsADRP     : Predicate<"!Subtarget->hasTempRegsADRP()">;
-
 def hasUMADDL           : Predicate<"!Subtarget->avoidUMADDL()">;
 
 //===----------------------------------------------------------------------===//
@@ -457,7 +454,11 @@ def ADJCALLSTACKUP : Pseudo<(outs), (ins i32imm:$amt1, i32imm:$amt2),
                             Sched<[]>;
 } // Defs = [SP], Uses = [SP], hasSideEffects = 1, isCodeGenOnly = 1
 
+#ifndef UNIFICO_REMAT_RULES
+let isReMaterializable = 1, isCodeGenOnly = 1, isAsCheapAsAMove = 0 in {
+#else
 let isReMaterializable = 1, isCodeGenOnly = 1, isAsCheapAsAMove = 1 in {
+#endif
 // FIXME: The following pseudo instructions are only needed because remat
 // cannot handle multiple instructions.  When that changes, they can be
 // removed, along with the AArch64Wrapper node.
@@ -1656,15 +1657,29 @@ def : InstAlias<"cneg $dst, $src, $cc",
 // PC-relative instructions.
 //===----------------------------------------------------------------------===//
 
+#ifndef UNIFICO_REMAT_RULES
+let isReMaterializable = 1, isAsCheapAsAMove = 0 in {
+#else
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in {
+#endif
+
 let hasSideEffects = 0, mayStore = 0, mayLoad = 0 in {
+
 def ADR  : ADRI<0, "adr", adrlabel,
+#ifndef UNIFICO_REMAT_RULES
+                [(set GPR64:$Xd, (AArch64adr tglobaladdr:$label))]>;
+#else
                 [(set GPR64temp:$Xd, (AArch64adr tglobaladdr:$label))]>;
+#endif
 } // hasSideEffects = 0
 
 def ADRP : ADRI<1, "adrp", adrplabel,
+#ifndef UNIFICO_REMAT_RULES
+                [(set GPR64:$Xd, (AArch64adr tglobaladdr:$label))]>;
+#else
                 [(set GPR64temp:$Xd, (AArch64adrp tglobaladdr:$label))]>;
-} // isReMaterializable = 0, isAsCheapAsAMove = 1
+#endif
+} // isReMaterializable = 1, isAsCheapAsAMove = 1
 
 // page address of a constant pool entry, block address
 def : Pat<(AArch64adr tconstpool:$cp), (ADR tconstpool:$cp)>;

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -135,16 +135,27 @@ def FFR : AArch64Reg<0, "ffr">, DwarfRegNum<[47]>;
 
 // GPR register classes with the intersections of GPR32/GPR32sp and
 // GPR64/GPR64sp for use by the coalescer.
+
+#ifndef UNIFICO_GPR_CALLING_CONV
+def GPR32common : RegisterClass<"AArch64", [i32], 32, (sequence "W%u", 0, 30)> {
+#else
 def GPR32common : RegisterClass<"AArch64", [i32], 32,
                                 (add (sequence "W%u", 0, 8), (sequence "W%u", 16, 20), W29, W30)> {
+#endif
   let AltOrders = [(rotl GPR32common, 8)];
   let AltOrderSelect = [{ return 1; }];
 }
+
 def GPR64common : RegisterClass<"AArch64", [i64], 64,
+#ifndef UNIFICO_GPR_CALLING_CONV
+                                (add (sequence "X%u", 0, 28), FP, LR)> {
+#else
                                 (add (sequence "X%u", 0, 8), (sequence "X%u", 16, 20), FP, LR)> {
+#endif
   let AltOrders = [(rotl GPR64common, 8)];
   let AltOrderSelect = [{ return 1; }];
 }
+
 // GPR register classes which exclude SP/WSP.
 def GPR32 : RegisterClass<"AArch64", [i32], 32, (add GPR32common, WZR)> {
   let AltOrders = [(rotl GPR32, 8)];
@@ -195,8 +206,14 @@ def GPR64z : RegisterOperand<GPR64> {
 }
 
 // GPR argument registers.
+
+#ifndef UNIFICO_GPR_CALLING_CONV
+def GPR32arg : RegisterClass<"AArch64", [i32], 32, (sequence "W%u", 0, 7)>;
+def GPR64arg : RegisterClass<"AArch64", [i64], 64, (sequence "X%u", 0, 7)>;
+#else
 def GPR32arg : RegisterClass<"AArch64", [i32], 32, (sequence "W%u", 0, 5)>;
 def GPR64arg : RegisterClass<"AArch64", [i64], 64, (sequence "X%u", 0, 5)>;
+#endif
 
 // GPR register classes which include WZR/XZR AND SP/WSP. This is not a
 // constraint used by any instructions, it is used as a common super-class.

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -443,23 +443,47 @@ def Q30   : AArch64Reg<30, "q30", [D30], ["v30", ""]>, DwarfRegAlias<B30>;
 def Q31   : AArch64Reg<31, "q31", [D31], ["v31", ""]>, DwarfRegAlias<B31>;
 }
 
+#ifndef UNIFICO_FPR_CALLING_CONV
+def FPR8  : RegisterClass<"AArch64", [untyped], 8, (sequence "B%u", 0, 31)> {
+#else
 def FPR8  : RegisterClass<"AArch64", [untyped], 8, (sequence "B%u", 0, 15)> {
+#endif
   let Size = 8;
 }
+
+#ifndef UNIFICO_FPR_CALLING_CONV
+def FPR16 : RegisterClass<"AArch64", [f16], 16, (sequence "H%u", 0, 31)> {
+#else
 def FPR16 : RegisterClass<"AArch64", [f16], 16, (sequence "H%u", 0, 15)> {
+#endif
   let Size = 16;
 }
+
+#ifndef UNIFICO_FPR_CALLING_CONV
+def FPR32 : RegisterClass<"AArch64", [f32, i32], 32,(sequence "S%u", 0, 31)>;
+#else
 def FPR32 : RegisterClass<"AArch64", [f32, i32], 32,(sequence "S%u", 0, 15)>;
+#endif
+
 def FPR64 : RegisterClass<"AArch64", [f64, i64, v2f32, v1f64, v8i8, v4i16, v2i32,
                                     v1i64, v4f16],
+#ifndef UNIFICO_FPR_CALLING_CONV
+                                    64, (sequence "D%u", 0, 31)>;
+#else
                                     64, (sequence "D%u", 0, 15)>;
+#endif
+
 // We don't (yet) have an f128 legal type, so don't use that here. We
 // normalize 128-bit vectors to v2f64 for arg passing and such, so use
 // that here.
 def FPR128 : RegisterClass<"AArch64",
                            [v16i8, v8i16, v4i32, v2i64, v4f32, v2f64, f128,
                             v8f16],
+#ifndef UNIFICO_FPR_CALLING_CONV
+                           128, (sequence "Q%u", 0, 31)>;
+#else
                            128, (sequence "Q%u", 0, 15)>;
+#endif
 
 // The lower 16 vector registers.  Some instructions can only take registers
 // in this range.

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -176,11 +176,13 @@ def GPR64sp : RegisterClass<"AArch64", [i64], 64, (add GPR64common, SP)> {
   let AltOrderSelect = [{ return 1; }];
 }
 
+#ifdef UNIFICO_REMAT_RULES
 def GPR64temp : RegisterClass<"AArch64", [i64], 64,
                                 (add (sequence "X%u", 6, 8), (sequence "X%u", 16, 18))> {
   let AltOrders = [(rotl GPR64temp, 8)];
   let AltOrderSelect = [{ return 1; }];
 }
+#endif
 
 def GPR32sponly : RegisterClass<"AArch64", [i32], 32, (add WSP)>;
 def GPR64sponly : RegisterClass<"AArch64", [i64], 64, (add SP)>;

--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -1046,7 +1046,12 @@ def CC_X86 : CallingConv<[
 def CSR_NoRegs : CalleeSavedRegs<(add)>;
 
 def CSR_32 : CalleeSavedRegs<(add ESI, EDI, EBX, EBP)>;
+
+#ifndef UNIFICO_GPR_CALLING_CONV
+def CSR_64 : CalleeSavedRegs<(add RBX, R12, R13, R14, R15, RBP)>;
+#else
 def CSR_64 : CalleeSavedRegs<(add R15, RBX, RBP)>;
+#endif
 
 def CSR_64_SwiftError : CalleeSavedRegs<(sub CSR_64, R12)>;
 

--- a/llvm/lib/Target/X86/X86InstrArithmetic.td
+++ b/llvm/lib/Target/X86/X86InstrArithmetic.td
@@ -31,7 +31,11 @@ def LEA64_32r : I<0x8D, MRMSrcMem,
                   [(set GR32:$dst, lea64_32addr:$src)]>,
                   OpSize32, Requires<[In64BitMode]>;
 
+#ifndef UNIFICO_REMAT_RULES
+let isReMaterializable = 1, isAsCheapAsAMove = 0 in
+#else
 let isReMaterializable = 1, isAsCheapAsAMove = 1 in
+#endif
 def LEA64r   : RI<0x8D, MRMSrcMem, (outs GR64:$dst), (ins lea64mem:$src),
                   "lea{q}\t{$src|$dst}, {$dst|$src}",
                   [(set GR64:$dst, lea64addr:$src)]>;

--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -265,8 +265,13 @@ def MORESTACK_RET_RESTORE_R10 : I<0, Pseudo, (outs), (ins), "", []>;
 // FIXME: remove when we can teach regalloc that xor reg, reg is ok.
 let Defs = [EFLAGS], isReMaterializable = 1, isAsCheapAsAMove = 1,
     isPseudo = 1, isMoveImm = 1, AddedComplexity = 10 in
+#ifndef UNIFICO_REGALLOC_RULES
+def MOV32r0  : I<0, Pseudo, (outs GR32:$dst), (ins), "",
+                 [(set GR32:$dst, 0)]>, Sched<[WriteZero]>;
+#else
 def MOV32r0  : I<0, Pseudo, (outs GR32temp:$dst), (ins), "",
                  [(set GR32temp:$dst, 0)]>, Sched<[WriteZero]>;
+#endif
 
 // Other widths can also make use of the 32-bit xor, which may have a smaller
 // encoding and avoid partial register updates.

--- a/llvm/lib/Target/X86/X86InstrSSE.td
+++ b/llvm/lib/Target/X86/X86InstrSSE.td
@@ -255,7 +255,11 @@ defm MOVSS : sse12_move<FR32, X86Movss, v4f32, f32mem, "movss",
 defm MOVSD : sse12_move<FR64, X86Movsd, v2f64, f64mem, "movsd",
                         SSEPackedDouble, "MOVSD", UseSSE2>, XD;
 
+#ifndef UNIFICO_REMAT_RULES
+let canFoldAsLoad = 1, isReMaterializable = 1 in {
+#else
 let canFoldAsLoad = 1, isReMaterializable = 0 in {
+#endif
   defm MOVSS : sse12_move_rm<FR32, v4f32, f32mem, loadf32, X86vzload32, "movss",
                              SSEPackedSingle>, XS;
   defm MOVSD : sse12_move_rm<FR64, v2f64, f64mem, loadf64, X86vzload64, "movsd",

--- a/llvm/lib/Target/X86/X86RegisterInfo.td
+++ b/llvm/lib/Target/X86/X86RegisterInfo.td
@@ -73,11 +73,16 @@ def R11B : X86Reg<"r11b", 11>;
 def R12B : X86Reg<"r12b", 12>;
 def R13B : X86Reg<"r13b", 13>;
 def R14B : X86Reg<"r14b", 14>;
+#ifndef UNIFICO_REGALLOC_RULES
+def R15B : X86Reg<"r15b", 15>;
+#endif
 }
 
+#ifdef UNIFICO_REGALLOC_RULES
 let CostPerUse = 0 in {
 def R15B : X86Reg<"r15b", 15>;
 }
+#endif
 
 let isArtificial = 1 in {
 // High byte of the low 16 bits of the super-register:
@@ -138,12 +143,18 @@ def R11W : X86Reg<"r11w", 11, [R11B,R11BH]>;
 def R12W : X86Reg<"r12w", 12, [R12B,R12BH]>;
 def R13W : X86Reg<"r13w", 13, [R13B,R13BH]>;
 def R14W : X86Reg<"r14w", 14, [R14B,R14BH]>;
+#ifndef UNIFICO_REGALLOC_RULES
+def R15W : X86Reg<"r15w", 15, [R15B,R15BH]>;
+#endif
 }
 
+#ifdef UNIFICO_REGALLOC_RULES
 let SubRegIndices = [sub_8bit, sub_8bit_hi_phony], CostPerUse = 0,
     CoveredBySubRegs = 1 in {
 def R15W : X86Reg<"r15w", 15, [R15B,R15BH]>;
 }
+#endif
+
 // 32-bit registers
 let SubRegIndices = [sub_16bit, sub_16bit_hi], CoveredBySubRegs = 1 in {
 def EAX : X86Reg<"eax", 0, [AX, HAX]>, DwarfRegNum<[-2, 0, 0]>;
@@ -167,12 +178,18 @@ def R11D : X86Reg<"r11d", 11, [R11W,R11WH]>;
 def R12D : X86Reg<"r12d", 12, [R12W,R12WH]>;
 def R13D : X86Reg<"r13d", 13, [R13W,R13WH]>;
 def R14D : X86Reg<"r14d", 14, [R14W,R14WH]>;
+#ifndef UNIFICO_REGALLOC_RULES
+def R15D : X86Reg<"r15d", 15, [R15W,R15WH]>;
+#endif
 }
 
+#ifdef UNIFICO_REGALLOC_RULES
 let SubRegIndices = [sub_16bit, sub_16bit_hi], CostPerUse = 0,
     CoveredBySubRegs = 1 in {
 def R15D : X86Reg<"r15d", 15, [R15W,R15WH]>;
 }
+#endif
+
 // 64-bit registers, X86-64 only
 let SubRegIndices = [sub_32bit] in {
 def RAX : X86Reg<"rax", 0, [EAX]>, DwarfRegNum<[0, -2, -2]>;
@@ -193,13 +210,18 @@ def R11 : X86Reg<"r11", 11, [R11D]>, DwarfRegNum<[11, -2, -2]>;
 def R12 : X86Reg<"r12", 12, [R12D]>, DwarfRegNum<[12, -2, -2]>;
 def R13 : X86Reg<"r13", 13, [R13D]>, DwarfRegNum<[13, -2, -2]>;
 def R14 : X86Reg<"r14", 14, [R14D]>, DwarfRegNum<[14, -2, -2]>;
+#ifndef UNIFICO_REGALLOC_RULES
+def R15 : X86Reg<"r15", 15, [R15D]>, DwarfRegNum<[15, -2, -2]>;
+#endif
 def RIP : X86Reg<"rip",  0, [EIP]>,  DwarfRegNum<[16, -2, -2]>;
 }}
 
+#ifdef UNIFICO_REGALLOC_RULES
 let SubRegIndices = [sub_32bit] in {
 let CostPerUse = 0 in {
 def R15 : X86Reg<"r15", 15, [R15D]>, DwarfRegNum<[15, -2, -2]>;
 }}
+#endif
 
 // MMX Registers. These are actually aliased to ST0 .. ST7
 def MM0 : X86Reg<"mm0", 0>, DwarfRegNum<[41, 29, 29]>;
@@ -422,9 +444,11 @@ def GR32 : RegisterClass<"X86", [i32], 32,
                          (add EAX, ECX, EDX, ESI, EDI, EBX, EBP, ESP,
                               R8D, R9D, R10D, R11D, R14D, R15D, R12D, R13D)>;
 
+#ifdef UNIFICO_REGALLOC_RULES
 def GR32temp : RegisterClass<"X86", [i32], 32,
                          (add EAX, ECX, EDX, ESI, EDI,
                               R8D, R9D, R10D, R11D, R14D, R12D, R13D)>;
+#endif
 
 // GR64 - 64-bit GPRs. This oddly includes RIP, which isn't accurate, since
 // RIP isn't really a register and it can't be used anywhere except in an


### PR DESCRIPTION
This PR showcases:

- Addition of entry point CMake flag to inject Unifico-specific options (in our case we are interested in macros)

This is mostly a draft to test that we can actually use this facility relating to https://github.com/systems-nuts/unifico/issues/60
The interesting part is that it is not used anywhere in LLVM 9 except for TableGen's unit tests.

A few things to consider are:

- What kind of macro groups do we want (i.e., feature sets)?
- Changing those flags in CMake once the project has been configured requires invalidating its cache (`CMakeCache.txt`).  
  The TableGen invocations are already set during configuration in the build tool's configuration (i.e., the one that CMake generates), such as `ninja`.
- TableGen invocations can also happen per project; not sure we want that, because at the moment only two projects are invoking it, clang and llvm.

Please check this branch out and verify that it does what you want (it works for me).

You can pass your TableGen macros during CMake configuration:

```
cmake \
... \
-DLLVM_UNIFICO_TABLEGEN_FEATURES="-DUNIFICO_FEATURE_SET1;-DUNIFICO_FEATURE_SET2"
```

and remove them, remove the CMake cache, reconfigure and rebuild.