### PR TITLE
[layout] Copy WZR only to temporary registers

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -875,6 +875,15 @@ public:
     return false;
   }
 
+  /// This method is only called when emitting the COPY instruction from the
+  /// CopyFromReg SDNode. It checks whether the register being copied is the
+  /// zero register, if provided by the architecture, and returns true in that
+  /// case. This way, targets can choose to copy the zero register only to
+  /// specific register classes.
+  virtual bool requiresRegClassOfCopiedReg(unsigned &SrcReg) const {
+    return false;
+  }
+
   /// Return true if target has reserved a spill slot in the stack frame of
   /// the given function for the specified register. e.g. On x86, if the frame
   /// register is required, the first fixed stack object is reserved as its

--- a/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
@@ -159,6 +159,9 @@ EmitCopyFromReg(SDNode *Node, unsigned ResNo, bool IsClone, bool IsCloned,
   // Figure out the register class to create for the destreg.
   if (VRBase) {
     DstRC = MRI->getRegClass(VRBase);
+    if (TRI->requiresRegClassOfCopiedReg(SrcReg)) {
+      DstRC = SrcRC;
+    }
   } else if (UseRC) {
     assert(TRI->isTypeLegalForClass(*UseRC, VT) &&
            "Incompatible phys register def and uses!");

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -562,3 +562,7 @@ unsigned AArch64RegisterInfo::getLocalAddressRegister(
     return getBaseRegister();
   return getFrameRegister(MF);
 }
+
+bool AArch64RegisterInfo::requiresRegClassOfCopiedReg(unsigned &SrcReg) const {
+  return SrcReg == AArch64::WZR;
+}

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
@@ -126,6 +126,8 @@ public:
   }
 
   unsigned getLocalAddressRegister(const MachineFunction &MF) const;
+
+  bool requiresRegClassOfCopiedReg(unsigned int &SrcReg) const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -176,6 +176,18 @@ def GPR64sp : RegisterClass<"AArch64", [i64], 64, (add GPR64common, SP)> {
   let AltOrderSelect = [{ return 1; }];
 }
 
+#ifdef UNIFICO_REGALLOC_RULES
+// GPR register class which only includes 32-bit temporary registers and the zero register.
+// This is useful when we want to assign the zero register to only temporary registers,
+// since for X86 we are using MOV32r0 instead, which for now we only assign to temporary registers.
+// This will be achieved through calling `TargetRegisterInfo::getMinimalPhysRegClass`.
+def GPR32temp : RegisterClass<"AArch64", [i32], 32,
+                                (add (sequence "W%u", 0, 8), (sequence "W%u", 16, 18), WZR)> {
+  let AltOrders = [(rotl GPR32temp, 8)];
+  let AltOrderSelect = [{ return 1; }];
+}
+#endif
+
 #ifdef UNIFICO_REMAT_RULES
 def GPR64temp : RegisterClass<"AArch64", [i64], 64,
                                 (add (sequence "X%u", 6, 8), (sequence "X%u", 16, 18))> {


### PR DESCRIPTION
The way AArch64 propagates the zero value is by assigning the zero register to another register, which is, potentially, copied further. Since with X86 we implement the equivalent functionality with `MOV32r0`, which we only copy to temporary registers, we need to make sure that in AArch64 the zero register and its subsequent copies are only allowed to temp registers as well.

Addresses: https://github.com/systems-nuts/unifico/issues/256