### PR TITLE
[layout] Add flag to control copying WZR to temp registers

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -880,7 +880,8 @@ public:
   /// zero register, if provided by the architecture, and returns true in that
   /// case. This way, targets can choose to copy the zero register only to
   /// specific register classes.
-  virtual bool requiresRegClassOfCopiedReg(unsigned &SrcReg) const {
+  virtual bool requiresRegClassOfCopiedReg(const MachineFunction &MF,
+                                           unsigned &SrcReg) const {
     return false;
   }
 

--- a/llvm/lib/CodeGen/RegisterCoalescer.cpp
+++ b/llvm/lib/CodeGen/RegisterCoalescer.cpp
@@ -1697,7 +1697,7 @@ void RegisterCoalescer::updateRegDefsUses(unsigned SrcReg,
     // operand (which should be the same as the class of the zero register, from
     // an earlier use of `requiresRegClassOfCopiedReg` in the InstrEmitter.
     // TODO: Check if `isCopy()` is enough, or `isCopyLike()` is needed.
-    if (UseMI->isCopy() && TRI->requiresRegClassOfCopiedReg(DstReg)) {
+    if (UseMI->isCopy() && TRI->requiresRegClassOfCopiedReg(*MF, DstReg)) {
       MachineOperand &CopyDstMO = UseMI->getOperand(0);
       MachineOperand &CopySrcMO = UseMI->getOperand(1);
 

--- a/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/InstrEmitter.cpp
@@ -159,7 +159,7 @@ EmitCopyFromReg(SDNode *Node, unsigned ResNo, bool IsClone, bool IsCloned,
   // Figure out the register class to create for the destreg.
   if (VRBase) {
     DstRC = MRI->getRegClass(VRBase);
-    if (TRI->requiresRegClassOfCopiedReg(SrcReg)) {
+    if (TRI->requiresRegClassOfCopiedReg(*MF, SrcReg)) {
       DstRC = SrcRC;
     }
   } else if (UseRC) {

--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -371,6 +371,11 @@ def FeatureAvoidF128 : SubtargetFeature<"avoid-f128", "AvoidF128",
 def FeatureAvoidUMADDL : SubtargetFeature<"avoid-wide-mul-add", "AvoidUMADDL",
     "true", "Disable the use of wide multiplication-addition of 32-bit to 64-bit.">;
 
+// Whether to enable the `requiresRegClassOfCopiedReg` check or not.
+// See TargetRegisterInfo.h for more details.
+def FeatureCopyWZRToTemp : SubtargetFeature<"copy-wzr-temp", "HasCopyWZRToTemp",
+    "true", "Copy the wzr register only to temporary registers.">;
+
 //===----------------------------------------------------------------------===//
 // Architectures.
 //

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -563,6 +563,10 @@ unsigned AArch64RegisterInfo::getLocalAddressRegister(
   return getFrameRegister(MF);
 }
 
-bool AArch64RegisterInfo::requiresRegClassOfCopiedReg(unsigned &SrcReg) const {
-  return SrcReg == AArch64::WZR;
+bool AArch64RegisterInfo::requiresRegClassOfCopiedReg(const MachineFunction &MF,
+                                                      unsigned &SrcReg) const {
+  if (MF.getSubtarget<AArch64Subtarget>().hasCopyWZRToTemp())
+    return SrcReg == AArch64::WZR;
+  else
+    return false;
 }

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
@@ -127,7 +127,8 @@ public:
 
   unsigned getLocalAddressRegister(const MachineFunction &MF) const;
 
-  bool requiresRegClassOfCopiedReg(unsigned int &SrcReg) const override;
+  bool requiresRegClassOfCopiedReg(const MachineFunction &MF,
+                                   unsigned int &SrcReg) const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -140,6 +140,7 @@ protected:
   bool TempRegsADRP = false;
   bool AvoidF128 = false;
   bool AvoidUMADDL = false;
+  bool HasCopyWZRToTemp = false;
 
   // Arm SVE2 extensions
   bool HasSVE2AES = false;
@@ -395,6 +396,7 @@ public:
   bool hasTempRegsADRP() const { return TempRegsADRP; }
   bool avoidF128() const { return AvoidF128; }
   bool avoidUMADDL() const { return AvoidUMADDL; }
+  bool hasCopyWZRToTemp() const { return HasCopyWZRToTemp; }
   // Arm SVE2 extensions
   bool hasSVE2AES() const { return HasSVE2AES; }
   bool hasSVE2SM4() const { return HasSVE2SM4; }


### PR DESCRIPTION
This extends https://github.com/blackgeorge-boom/llvm-project/pull/51, by adding the `copy-wzr-temp` AArch64 subtarget flag, in order to conditionally enable the functionality introduced by that PR.