### PR TITLE
[layout] Fix order of checking VRs after arch-specific value creation

### DIFF
--- a/llvm/lib/CodeGen/StackTransformMetadata.cpp
+++ b/llvm/lib/CodeGen/StackTransformMetadata.cpp
@@ -1380,8 +1380,8 @@ void StackTransformMetadata::findArchSpecificLiveVals() {
                 }
 
                 SeenDefs.insert(DefinitionMI);
-                sanitizeVregs(MLV, MISM);
                 MLV = TVG->getMachineValue(DefinitionMI);
+                sanitizeVregs(MLV, MISM);
 
                 if (MLV)
                   break; // We got a value!


### PR DESCRIPTION
When we are adding arch-specific stack slots, we need to use `sanitizeVRegs` after we create a value, not before. Otherwise, we will not check correctly if a virtual register has not been handled by the stackmap and when we will try to lower the register as part of the arch-specific value, we will fail.

Addresses: https://github.com/systems-nuts/unifico/issues/275