### PR TITLE
Force alignment of all objects in the stack to be at least four bytes

### DIFF
--- a/llvm/lib/CodeGen/StackSlotColoring.cpp
+++ b/llvm/lib/CodeGen/StackSlotColoring.cpp
@@ -50,6 +50,12 @@ DisableSharing("no-stack-slot-sharing",
              cl::init(false), cl::Hidden,
              cl::desc("Suppress slot sharing during stack coloring"));
 
+static cl::opt<bool>
+    AlignObjectsToFour("align-objects-to-four",
+                       cl::desc("Hard-code the alignment of all objects in the"
+                                "stack to by at least four bytes."),
+                       cl::init(false), cl::Hidden);
+
 static cl::opt<int> DCELimit("ssc-dce-limit", cl::init(-1), cl::Hidden);
 
 STATISTIC(NumEliminated, "Number of stack slots eliminated due to coloring");
@@ -309,6 +315,8 @@ int StackSlotColoring::ColorSlot(LiveInterval *li) {
   // objects sharing the same slot, then make sure the size and alignment
   // are large enough for all.
   unsigned Align = OrigAlignments[FI];
+  if (AlignObjectsToFour)
+    Align = std::max(Align, 4u);
   if (!Share || Align > MFI->getObjectAlignment(Color))
     MFI->setObjectAlignment(Color, Align);
   int64_t Size = OrigSizes[FI];


### PR DESCRIPTION
This happens inside the stack-slot-coloring pass. For some reason, there are cases where our `-align-bytes-to-four` flag does not work, for example when lowering instructions that use `ccond`, which uses 32 bits in AArch64 and 8 bits in X86. We add an extra flag to hard-code that all stack objects should be aligned at a four-byte boundary at least.

Addresses: https://github.com/systems-nuts/unifico/issues/279