### PR TITLE
Convert AArch64 ADD/SUB-rr instructions to the two-address format

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -2055,11 +2055,17 @@ class AddSubImmShift<bit isSub, bit setFlags, RegisterClass dstRegtype,
   let DecoderMethod = "DecodeAddSubImmShift";
 }
 
+#ifdef UNIFICO_AARCH64_TWOADDR
+let Constraints = "$Rd = $Rn" in {
+#endif
 class BaseAddSubRegPseudo<RegisterClass regtype,
                           SDPatternOperator OpNode>
     : Pseudo<(outs regtype:$Rd), (ins regtype:$Rn, regtype:$Rm),
              [(set regtype:$Rd, (OpNode regtype:$Rn, regtype:$Rm))]>,
       Sched<[WriteI, ReadI, ReadI]>;
+#ifdef UNIFICO_AARCH64_TWOADDR
+}
+#endif
 
 class BaseAddSubSReg<bit isSub, bit setFlags, RegisterClass regtype,
                      arith_shifted_reg shifted_regtype, string asm,
@@ -2167,8 +2173,14 @@ multiclass AddSub<bit isSub, string mnemonic, string alias,
   }
 
   // Add/Subtract register - Only used for CodeGen
+#ifdef UNIFICO_AARCH64_TWOADDR
+  let isCommutable = 1 in {
+#endif
   def Wrr : BaseAddSubRegPseudo<GPR32, OpNode>;
   def Xrr : BaseAddSubRegPseudo<GPR64, OpNode>;
+#ifdef UNIFICO_AARCH64_TWOADDR
+  }
+#endif
 
   // Add/Subtract shifted register
   def Wrs : BaseAddSubSReg<isSub, 0, GPR32, arith_shifted_reg32, mnemonic,
@@ -2242,8 +2254,14 @@ multiclass AddSubS<bit isSub, string mnemonic, SDNode OpNode, string cmp,
   }
 
   // Add/Subtract register
+#ifdef UNIFICO_AARCH64_TWOADDR
+  let isCommutable = 1 in {
+#endif
   def Wrr : BaseAddSubRegPseudo<GPR32, OpNode>;
   def Xrr : BaseAddSubRegPseudo<GPR64, OpNode>;
+#ifdef UNIFICO_AARCH64_TWOADDR
+  }
+#endif
 
   // Add/Subtract shifted register
   def Wrs : BaseAddSubSReg<isSub, 1, GPR32, arith_shifted_reg32, mnemonic,

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -2056,7 +2056,7 @@ class AddSubImmShift<bit isSub, bit setFlags, RegisterClass dstRegtype,
 }
 
 #ifdef UNIFICO_AARCH64_TWOADDR
-let Constraints = "$Rd = $Rn" in {
+let Constraints = "$Rd = $Rn", isConvertibleToThreeAddress = 1 in {
 #endif
 class BaseAddSubRegPseudo<RegisterClass regtype,
                           SDPatternOperator OpNode>

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -265,6 +265,35 @@ public:
   /// on Windows.
   static bool isSEHInstruction(const MachineInstr &MI);
 
+  /// Given an operand within a MachineInstr, insert preceding code to put it
+  /// into the right format for a particular kind of LEA-like instruction in
+  /// AArch64. This may involve using an appropriate super-register instead
+  /// (with an implicit use of the original) or creating a new virtual register
+  /// and inserting COPY instructions to get the data into the right class.
+  ///
+  /// Reference parameters are set to indicate how caller should add this
+  /// operand to the LEA-like instruction.
+  bool classifyADDReg(MachineInstr &MI, const MachineOperand &Src,
+                      unsigned LEAOpcode, bool AllowSP, unsigned &NewSrc,
+                      bool &isKill, MachineOperand &ImplicitOp,
+                      LiveVariables *LV) const;
+
+  /// convertToThreeAddress - This method must be implemented by targets that
+  /// set the M_CONVERTIBLE_TO_3_ADDR flag.  When this flag is set, the target
+  /// may be able to convert a two-address instruction into a true
+  /// three-address instruction on demand.  This allows the X86 target (for
+  /// example) to convert ADD and SHL instructions into LEA instructions if they
+  /// would require register copies due to two-addressness. To emulate this
+  /// behavior in AArch64, we just convert the ADD/SUB instructions to their
+  /// original three-address format.
+  ///
+  /// This method returns a null pointer if the transformation cannot be
+  /// performed, otherwise it returns the new instruction.
+  ///
+  MachineInstr *convertToThreeAddress(MachineFunction::iterator &MFI,
+                                      MachineInstr &MI,
+                                      LiveVariables *LV) const override;
+
 #define GET_INSTRINFO_HELPER_DECLS
 #include "AArch64GenInstrInfo.inc"
 

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -1010,7 +1010,8 @@ X86InstrInfo::convertToThreeAddress(MachineFunction::iterator &MFI,
     if (MIOpc == X86::ADD64rr || MIOpc == X86::ADD64rr_DB)
       Opc = X86::LEA64r;
     else
-      Opc = Is64Bit ? X86::LEA64_32r : X86::LEA32r;
+      Opc = Is64Bit ? (SmallLEAs ? X86::LEA32r : X86::LEA64_32r)
+               : X86::LEA32r;
 
     bool isKill;
     unsigned SrcReg;


### PR DESCRIPTION
When the two-address instruction pass is enabled, the ADD/SUB-rr instructions of AArch64 can now be converted to the tow-address format. This also requires support for converting them back to the three-address format, in the cases where X86 would do the same by converting these instructions into LEAs. Essentially, for AArch64 this just means that the instruction is copied back to its original three-address format.

Additionally, this patch introduces a small fix that uses `LEA32r` instead of `LEA64_32r` for the case of additions in X86.

Requires compiling with the `-DUNIFICO_TWO_ADDR` directive, along with the existing llc flag `enable-lea32`.

Addresses: https://github.com/systems-nuts/unifico/issues/283