### PR TITLE
[layout][X86] Do not convert SELECT to FSETCC

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -507,6 +507,14 @@ def FeatureAvoidOptimizingMulCase1: SubtargetFeature<"avoid-opt-mul-1",
                                         "AvoidOptimizingMulCase1", "true",
                                         "Avoid optimizing multiplication with (2^n + 2/4/6).">;
 
+// Avoid converting SETCC to FSETCC.
+// This would create a series of FANDN, FAND, and FOR instructions that are lowered using vector operands,
+// during PreprocessISelDAG, while AArch64 uses a simple FCMP instruction.
+// Instead, convert SETCC to a CMP in X86.
+def FeatureAvoidSelectToFSETCC: SubtargetFeature<"avoid-select-to-fsetcc",
+                                        "AvoidSelectToFSETCC", "true",
+                                        "Avoid converting SELECT to FSETCC.">;
+
 // Bonnell
 def ProcIntelAtom : SubtargetFeature<"", "X86ProcFamily", "IntelAtom", "">;
 // Silvermont

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -20637,7 +20637,7 @@ SDValue X86TargetLowering::LowerSELECT(SDValue Op, SelectionDAG &DAG) const {
       return DAG.getNode(X86ISD::SELECTS, DL, VT, Cmp, Op1, Op2);
     }
 
-    if (SSECC < 8 || Subtarget.hasAVX()) {
+    if (!Subtarget.avoidSelectToFSETCC() && (SSECC < 8 || Subtarget.hasAVX())) {
       SDValue Cmp = DAG.getNode(X86ISD::FSETCC, DL, VT, CondOp0, CondOp1,
                                 DAG.getConstant(SSECC, DL, MVT::i8));
 

--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -464,6 +464,9 @@ protected:
   /// Avoid optimizing mul with (2^n + 2/4/6)
   bool AvoidOptimizingMulCase1 = false;
 
+  /// Avoid converting SELECT to FSETCC
+  bool AvoidSelectToFSETCC = false;
+
   /// What processor and OS we're targeting.
   Triple TargetTriple;
 
@@ -725,6 +728,7 @@ public:
   bool hasAArch64ConstantCostModel() const { return AArch64ConstantCostModel; }
   bool hasSimpleRegOffsetAddr() const { return SimpleRegOffsetAddr; }
   bool forceVectorMemOp() const { return ForceVectorMemOp; }
+  bool avoidSelectToFSETCC() const { return AvoidSelectToFSETCC; }
   bool avoidOptimizingMulCase1() const { return AvoidOptimizingMulCase1; }
   bool hasINVPCID() const { return HasINVPCID; }
   bool hasENQCMD() const { return HasENQCMD; }


### PR DESCRIPTION
When `FSETCC` is lowered, a series of `FAND`, FANDN`, and `FOR` are generated. These make use of `v2f64` types, so X86 ends up spilling an SIMD `xxm` register. AArch64 on the other hand just generates `CMP` nodes, which end up using only one fp register.

We add an optional flag to disable this.

Addresses: https://github.com/systems-nuts/unifico/issues/284