### PR TITLE
[layout] Fix bug when coalescing temp regs to a subreg

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -746,6 +746,24 @@ public:
     return RC;
   }
 
+  /// Returns the largest temp register class for RC that is a class of
+  /// temporary registers. The returned register class can be used in copies
+  /// between virtual registers, where the destination is a virtual register
+  /// with a subregister and the source is a virtual register of a temp register
+  /// class. In this case, instead of just copying the source class to the
+  /// destination, as we do for temp register classes, we copy the
+  /// inflated version of the source class, which will be used for the
+  /// subregister later. For example, in:
+  ///     1744B	undef %223.sub_32:gpr64 = COPY $wzr
+  /// we cannot just copy the gpr32temp class to %223, because it
+  /// represents a 32-bit subregister of 64 bits.
+  virtual const TargetRegisterClass *
+  getLargestTempSuperClass(const TargetRegisterClass *RC,
+                           const MachineFunction &) const {
+    /// The default implementation just returns the original register class.
+    return RC;
+  }
+
   /// Return the register pressure "high water mark" for the specific register
   /// class. The scheduler is in high register pressure mode (for the specific
   /// register class) if it goes over the limit.

--- a/llvm/lib/CodeGen/RegisterCoalescer.cpp
+++ b/llvm/lib/CodeGen/RegisterCoalescer.cpp
@@ -1702,9 +1702,17 @@ void RegisterCoalescer::updateRegDefsUses(unsigned SrcReg,
       MachineOperand &CopySrcMO = UseMI->getOperand(1);
 
       if (CopyDstMO.isReg() && CopySrcMO.isReg() &&
-          CopyDstMO.getReg().isVirtual() && CopySrcMO.getReg().isVirtual())
-        MRI->setRegClass(CopyDstMO.getReg(),
-                         MRI->getRegClass(CopySrcMO.getReg()));
+          CopyDstMO.getReg().isVirtual() && CopySrcMO.getReg().isVirtual()) {
+
+        auto SrcRC = MRI->getRegClass(CopySrcMO.getReg());
+        const TargetRegisterClass *RC{};
+        if (CopyDstMO.getSubReg())
+          RC = TRI->getLargestTempSuperClass(SrcRC, *MF);
+        else
+          RC = SrcRC;
+
+        MRI->setRegClass(CopyDstMO.getReg(), RC);
+      }
     }
 
     // Replace SrcReg with DstReg in all UseMI operands.

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -570,3 +570,11 @@ bool AArch64RegisterInfo::requiresRegClassOfCopiedReg(const MachineFunction &MF,
   else
     return false;
 }
+
+const TargetRegisterClass *
+AArch64RegisterInfo::getLargestTempSuperClass(const TargetRegisterClass *RC,
+                                              const MachineFunction &MF) const {
+  if (RC == &AArch64::GPR32tempRegClass)
+    return &AArch64::GPR64tempRegClass;
+  return RC;
+}

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.h
@@ -129,6 +129,10 @@ public:
 
   bool requiresRegClassOfCopiedReg(const MachineFunction &MF,
                                    unsigned int &SrcReg) const override;
+
+  const TargetRegisterClass *
+  getLargestTempSuperClass(const TargetRegisterClass *RC,
+                           const MachineFunction &MF) const override;
 };
 
 } // end namespace llvm


### PR DESCRIPTION
When we are coalescing a temp register class, instead of blindly propagating the temporary class, we need to check whether the destination is a subregister. In this case, we may need to expand the temp register class, so that it fits the size of the destination class being subregistered.

Addresses: https://github.com/systems-nuts/unifico/issues/286